### PR TITLE
feat: per-pixel diffmap with multi-scale fusion, edge/MSE, masking

### DIFF
--- a/zensim/Cargo.toml
+++ b/zensim/Cargo.toml
@@ -43,6 +43,7 @@ rgb = { workspace = true, optional = true }
 image = { workspace = true }
 archmage = { workspace = true, features = ["testable_dispatch"] }
 serde_json = "1"
+
 [lints.clippy]
 uninlined_format_args = "allow"
 

--- a/zensim/examples/zensim_score.rs
+++ b/zensim/examples/zensim_score.rs
@@ -1,0 +1,25 @@
+use std::env;
+use zensim::{RgbSlice, Zensim, ZensimProfile};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        eprintln!("Usage: {} original.png distorted.png", args[0]);
+        std::process::exit(1);
+    }
+
+    let img1 = image::open(&args[1]).unwrap().to_rgb8();
+    let img2 = image::open(&args[2]).unwrap().to_rgb8();
+
+    let w = img1.width() as usize;
+    let h = img1.height() as usize;
+
+    let src: Vec<[u8; 3]> = img1.pixels().map(|p| p.0).collect();
+    let dst: Vec<[u8; 3]> = img2.pixels().map(|p| p.0).collect();
+
+    let z = Zensim::new(ZensimProfile::latest());
+    let s = RgbSlice::new(&src, w, h);
+    let d = RgbSlice::new(&dst, w, h);
+    let result = z.compute(&s, &d).unwrap();
+    println!("{:.8}", result.score());
+}

--- a/zensim/src/diffmap.rs
+++ b/zensim/src/diffmap.rs
@@ -1,0 +1,867 @@
+//! Per-pixel perceptual error map (diffmap) computation.
+//!
+//! Computes a multi-scale spatial error map from XYB-space planes using modified
+//! SSIM (same as the main metric). The diffmap fuses SSIM error maps from all
+//! pyramid scales, weighted by the profile's trained weights — coarser scales are
+//! upsampled to full resolution and blended. This captures both fine-grained and
+//! structural distortions.
+//!
+//! Designed for encoder quantization loops: the global zensim score tracks
+//! convergence, while the diffmap tells the encoder WHERE to adjust quality.
+
+use crate::metric::{FEATURES_PER_CHANNEL_BASIC, config_from_params, validate_pair};
+use crate::source::ImageSource;
+use crate::streaming::PrecomputedReference;
+use crate::{ZensimError, ZensimResult};
+
+/// Channel weighting scheme for combining per-channel SSIM error into
+/// the final diffmap.
+///
+/// The diffmap computes SSIM error independently on each XYB channel.
+/// This enum controls how those three per-channel error values are combined
+/// into a single per-pixel value.
+///
+/// # Which to use
+///
+/// - [`Trained`](Self::Trained) — best for encoder quant loops. Matches
+///   the trained model's view of what matters: almost pure luminance.
+/// - [`Balanced`](Self::Balanced) — useful for visualization or when you
+///   want color errors to be visible in the map even if the model
+///   doesn't weight them heavily at full resolution.
+/// - [`Custom`](Self::Custom) — full control. Weights are normalized
+///   to sum to 1.0.
+#[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
+pub enum DiffmapWeighting {
+    /// Per-scale weights derived from the profile's trained SSIM feature
+    /// weights. Each scale gets its own channel weights (SSIM features per
+    /// channel, normalized) and a blend weight proportional to the total
+    /// weight mass at that scale.
+    ///
+    /// For the default profile (v0.1), scale 0 (full res) contributes ~6%
+    /// of the blend, while scales 1-3 contribute ~28-35% each. At scale 0,
+    /// channel weights are Y-dominant (~99.3% luminance). At coarser scales,
+    /// color channels gain more influence.
+    ///
+    /// Automatically tracks the profile passed to [`Zensim::new`].
+    Trained,
+
+    /// Moderate Y-dominant weights with visible color contribution:
+    /// `[0.15, 0.70, 0.15]` (X, Y, B).
+    ///
+    /// Useful for visualization or when you want the diffmap to show
+    /// color distortion even though the trained model doesn't weight
+    /// it heavily for SSIM at scale 0.
+    Balanced,
+
+    /// Custom weights `[X, Y, B]`. Automatically normalized to sum to 1.0.
+    /// All values must be non-negative.
+    Custom([f32; 3]),
+}
+
+impl Default for DiffmapWeighting {
+    /// Defaults to [`Trained`](Self::Trained).
+    fn default() -> Self {
+        Self::Trained
+    }
+}
+
+/// Post-processing options for the diffmap signal.
+///
+/// These are applied after multi-scale fusion to shape the diffmap for
+/// specific use cases. All options default to off (raw SSIM error signal).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DiffmapOptions {
+    /// Channel weighting scheme (default: `Trained`).
+    pub weighting: DiffmapWeighting,
+
+    /// Apply contrast masking to suppress errors in complex/textured regions.
+    ///
+    /// When enabled, each diffmap value is divided by a local complexity mask
+    /// derived from the source image's luminance variance:
+    /// `mask = 1 + strength × local_variance(Y_src)`.
+    ///
+    /// This matches the perceptual intuition that errors in smooth areas
+    /// (sky, gradients) are more visible than in textured areas (foliage, hair).
+    ///
+    /// Default: `None` (no masking). Typical values: 2.0–8.0.
+    pub masking_strength: Option<f32>,
+
+    /// Apply `sqrt` to diffmap values after masking.
+    ///
+    /// Compresses the dynamic range so that the diffmap is more linearly
+    /// proportional to perceived distortion intensity. Similar to butteraugli's
+    /// `sqrt(dc_masked + ac_masked)` combination.
+    ///
+    /// Default: `false`.
+    pub sqrt: bool,
+
+    /// Include edge artifact, edge detail loss, and MSE features in the diffmap.
+    ///
+    /// When `false` (default), the diffmap only includes SSIM error.
+    /// When `true`, each pixel also accumulates:
+    /// - **Edge artifact**: `max(0, residual_dst² − residual_src²)` — structure
+    ///   added by distortion (ringing, blocking).
+    /// - **Edge detail loss**: `max(0, residual_src² − residual_dst²)` — structure
+    ///   removed by distortion (blurring, smoothing).
+    /// - **MSE**: `(src − dst)²` — raw per-pixel squared difference.
+    ///
+    /// Feature contributions are weighted by the profile's trained weights for
+    /// each feature type and channel. This makes the diffmap a more complete
+    /// representation of the metric's per-pixel view.
+    pub include_edge_mse: bool,
+}
+
+impl From<DiffmapWeighting> for DiffmapOptions {
+    fn from(w: DiffmapWeighting) -> Self {
+        Self {
+            weighting: w,
+            ..Default::default()
+        }
+    }
+}
+
+/// Per-pixel feature weights for a single channel in the diffmap.
+///
+/// When `art`, `det`, `mse` are all zero, only SSIM contributes (backward compatible).
+#[derive(Clone, Copy, Default)]
+pub(crate) struct PixelFeatureWeights {
+    pub ssim: f32,
+    pub art: f32,
+    pub det: f32,
+    pub mse: f32,
+}
+
+impl PixelFeatureWeights {
+    /// Whether any edge/MSE features are active (need mu1/mu2 storage).
+    pub fn needs_edge_mse(&self) -> bool {
+        self.art != 0.0 || self.det != 0.0 || self.mse != 0.0
+    }
+}
+
+impl DiffmapWeighting {
+    /// Return per-scale per-channel feature weights and scale blend weights.
+    ///
+    /// `per_scale_weights[s][c]` = feature weights for scale `s`, channel `c`.
+    /// `scale_blend_weights[s]` = fraction of total weight mass at scale `s`.
+    fn resolve_multiscale(
+        self,
+        profile_weights: &[f64],
+        num_scales: usize,
+        include_edge_mse: bool,
+    ) -> (Vec<[PixelFeatureWeights; 3]>, Vec<f32>) {
+        match self {
+            Self::Trained => {
+                trained_multiscale_weights(profile_weights, num_scales, include_edge_mse)
+            }
+            Self::Balanced => {
+                let pw = PixelFeatureWeights {
+                    ssim: 1.0,
+                    ..Default::default()
+                };
+                let ch = [
+                    PixelFeatureWeights { ssim: 0.15, ..pw },
+                    PixelFeatureWeights { ssim: 0.70, ..pw },
+                    PixelFeatureWeights { ssim: 0.15, ..pw },
+                ];
+                // For Balanced+edge_mse, distribute equally among features
+                let ch = if include_edge_mse {
+                    ch.map(|c| PixelFeatureWeights {
+                        ssim: c.ssim * 0.4,
+                        art: c.ssim * 0.2,
+                        det: c.ssim * 0.2,
+                        mse: c.ssim * 0.2,
+                    })
+                } else {
+                    ch
+                };
+                let blend = 1.0 / num_scales as f32;
+                (vec![ch; num_scales], vec![blend; num_scales])
+            }
+            Self::Custom(w) => {
+                let nw = normalize_weights(w);
+                let ch = [
+                    PixelFeatureWeights {
+                        ssim: nw[0],
+                        ..Default::default()
+                    },
+                    PixelFeatureWeights {
+                        ssim: nw[1],
+                        ..Default::default()
+                    },
+                    PixelFeatureWeights {
+                        ssim: nw[2],
+                        ..Default::default()
+                    },
+                ];
+                let ch = if include_edge_mse {
+                    ch.map(|c| PixelFeatureWeights {
+                        ssim: c.ssim * 0.4,
+                        art: c.ssim * 0.2,
+                        det: c.ssim * 0.2,
+                        mse: c.ssim * 0.2,
+                    })
+                } else {
+                    ch
+                };
+                let blend = 1.0 / num_scales as f32;
+                (vec![ch; num_scales], vec![blend; num_scales])
+            }
+        }
+    }
+}
+
+/// Derive per-scale per-feature channel weights and scale blend weights.
+///
+/// For each scale and channel, computes weights for SSIM, edge artifact,
+/// edge detail loss, and MSE features from the trained weight array.
+///
+/// When `include_edge_mse` is false, only SSIM features contribute
+/// (art/det/mse weights are 0).
+fn trained_multiscale_weights(
+    weights: &[f64],
+    num_scales: usize,
+    include_edge_mse: bool,
+) -> (Vec<[PixelFeatureWeights; 3]>, Vec<f32>) {
+    const FPC: usize = FEATURES_PER_CHANNEL_BASIC;
+    const FPS: usize = FPC * 3; // features per scale (basic only)
+
+    let mut per_scale = Vec::with_capacity(num_scales);
+    let mut scale_totals = Vec::with_capacity(num_scales);
+
+    for s in 0..num_scales {
+        let scale_base = s * FPS;
+        // Per-channel feature weight sums
+        let mut ssim_w = [0.0f64; 3];
+        let mut art_w = [0.0f64; 3];
+        let mut det_w = [0.0f64; 3];
+        let mut mse_w = [0.0f64; 3];
+        let mut scale_total = 0.0f64;
+
+        for c in 0..3 {
+            let base = scale_base + c * FPC;
+            if base + 2 < weights.len() {
+                ssim_w[c] = weights[base].abs() + weights[base + 1].abs() + weights[base + 2].abs();
+            }
+            if include_edge_mse && base + 9 < weights.len() {
+                art_w[c] =
+                    weights[base + 3].abs() + weights[base + 4].abs() + weights[base + 5].abs();
+                det_w[c] =
+                    weights[base + 6].abs() + weights[base + 7].abs() + weights[base + 8].abs();
+                mse_w[c] = weights[base + 9].abs();
+            }
+            // Sum ALL features at this scale for blend weight
+            for f in 0..FPC {
+                if base + f < weights.len() {
+                    scale_total += weights[base + f].abs();
+                }
+            }
+        }
+
+        // Normalize: all feature weights across all channels sum to 1.0
+        let feat_total: f64 = ssim_w.iter().sum::<f64>()
+            + art_w.iter().sum::<f64>()
+            + det_w.iter().sum::<f64>()
+            + mse_w.iter().sum::<f64>();
+
+        let ch_weights = if feat_total > 0.0 {
+            core::array::from_fn(|c| PixelFeatureWeights {
+                ssim: (ssim_w[c] / feat_total) as f32,
+                art: (art_w[c] / feat_total) as f32,
+                det: (det_w[c] / feat_total) as f32,
+                mse: (mse_w[c] / feat_total) as f32,
+            })
+        } else {
+            let eq = 1.0 / 3.0;
+            [PixelFeatureWeights {
+                ssim: eq,
+                ..Default::default()
+            }; 3]
+        };
+
+        per_scale.push(ch_weights);
+        scale_totals.push(scale_total);
+    }
+
+    // Normalize scale blend weights
+    let total: f64 = scale_totals.iter().sum();
+    let blend = if total > 0.0 {
+        scale_totals.iter().map(|&s| (s / total) as f32).collect()
+    } else {
+        let w = 1.0 / num_scales as f32;
+        vec![w; num_scales]
+    };
+
+    (per_scale, blend)
+}
+
+/// Apply contrast masking to the diffmap using source luminance variance.
+///
+/// Divides each diffmap value by `1 + strength * local_variance(Y_src)`,
+/// where local_variance is computed from the Y plane of the precomputed
+/// reference at scale 0, using a box-blur approximation.
+fn apply_contrast_masking(
+    diffmap: &mut [f32],
+    precomputed: &PrecomputedReference,
+    width: usize,
+    height: usize,
+    padded_width: usize,
+    strength: f32,
+) {
+    let (ref planes, pw, ph) = precomputed.scales[0];
+    debug_assert_eq!(pw, padded_width);
+    debug_assert_eq!(ph, height);
+    let y_plane = &planes[1]; // Y channel = luminance
+
+    // Compute local variance as mean(Y²) - mean(Y)² using a simple box average.
+    // Use a 5-pixel radius (11×11 window) matching the SSIM blur.
+    let r = 5usize;
+    for dy in 0..height {
+        for dx in 0..width {
+            let y0 = dy.saturating_sub(r);
+            let y1 = (dy + r + 1).min(height);
+            let x0 = dx.saturating_sub(r);
+            let x1 = (dx + r + 1).min(width);
+            let mut sum = 0.0f32;
+            let mut sum_sq = 0.0f32;
+            let mut count = 0.0f32;
+            for yy in y0..y1 {
+                for xx in x0..x1 {
+                    let v = y_plane[yy * padded_width + xx];
+                    sum += v;
+                    sum_sq += v * v;
+                    count += 1.0;
+                }
+            }
+            let mean = sum / count;
+            let variance = (sum_sq / count - mean * mean).max(0.0);
+            let mask = 1.0 + strength * variance;
+            diffmap[dy * width + dx] /= mask;
+        }
+    }
+}
+
+fn normalize_weights(w: [f32; 3]) -> [f32; 3] {
+    let sum = w[0] + w[1] + w[2];
+    if sum > 0.0 {
+        [w[0] / sum, w[1] / sum, w[2] / sum]
+    } else {
+        [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]
+    }
+}
+
+/// Result containing both a zensim score and a per-pixel error map.
+///
+/// The diffmap is a multi-scale spatial error map using modified SSIM across
+/// all three XYB channels. SSIM error maps are computed at each pyramid scale
+/// (4 scales by default), then coarser scales are upsampled to full resolution
+/// and blended with the profile's trained scale weights. This captures both
+/// fine-grained detail loss (scale 0) and structural/low-frequency distortions
+/// (scales 1-3).
+///
+/// It tells you WHERE perceptual error is concentrated, while the zensim score
+/// tells you HOW MUCH total error there is.
+///
+/// # Diffmap signal
+///
+/// Each value is a weighted blend of per-scale SSIM errors:
+///
+/// ```text
+/// per_channel_s = (1 − mean_term × structure_term).max(0)   [at scale s]
+///   mean_term      = 1 − (μ_src − μ_dst)²
+///   structure_term  = (2·σ_src_dst + C₂) / (σ²_src + σ²_dst + C₂)
+///   C₂ = 0.0009
+///
+/// scale_error_s[i] = Σ_c w_c_s × per_channel_s_c   (channel-weighted)
+/// diffmap[i] = Σ_s blend_s × upsample(scale_error_s)[i]   (scale-blended)
+/// ```
+///
+/// With trained weights: scale 0 gets ~6%, scales 1-3 get ~28-35% each
+/// (matching the trained model's emphasis on structural features).
+///
+/// - **Range**: `[0, +∞)`. Zero means perceptually identical at that location.
+///   Values above ~0.5 indicate severe local distortion. On typical photo pairs,
+///   most values fall in `[0, 0.3]`.
+/// - **Spatial smoothing**: scale 0 reflects 11×11 neighborhoods, coarser scales
+///   reflect progressively larger areas (22×22, 44×44, 88×88).
+/// - **Color space**: computed in XYB (perceptual luma + chroma). Channel
+///   combination weights are controlled by [`DiffmapWeighting`].
+/// - **Not butteraugli distance**: the values are unitless SSIM error, not
+///   butteraugli distance units. Use the global zensim score for overall quality.
+///
+/// # Layout
+///
+/// Row-major, `width × height` elements: `diffmap[y * width + x]`.
+/// No padding — actual image dimensions, not SIMD-padded.
+#[non_exhaustive]
+pub struct DiffmapResult {
+    result: ZensimResult,
+    diffmap: Vec<f32>,
+    width: usize,
+    height: usize,
+}
+
+impl DiffmapResult {
+    /// The full zensim comparison result (score, features, etc.).
+    pub fn result(&self) -> &ZensimResult {
+        &self.result
+    }
+
+    /// The zensim score (convenience shorthand for `result().score()`).
+    pub fn score(&self) -> f64 {
+        self.result.score()
+    }
+
+    /// Per-pixel perceptual error map. See [`DiffmapResult`] for signal
+    /// definition, range, and layout.
+    pub fn diffmap(&self) -> &[f32] {
+        &self.diffmap
+    }
+
+    /// Consume this result and return the diffmap as an owned `Vec<f32>`,
+    /// along with the zensim result and dimensions.
+    pub fn into_parts(self) -> (ZensimResult, Vec<f32>, usize, usize) {
+        (self.result, self.diffmap, self.width, self.height)
+    }
+
+    /// Image width (actual, not SIMD-padded).
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Image height.
+    pub fn height(&self) -> usize {
+        self.height
+    }
+}
+
+impl crate::metric::Zensim {
+    /// Compare with precomputed reference and return both score and per-pixel error map.
+    ///
+    /// The diffmap fuses SSIM error maps from all pyramid scales, weighted by the
+    /// profile's trained weights. Coarser scales are upsampled to full resolution
+    /// and blended. The zensim score uses the identical multi-scale pipeline.
+    ///
+    /// # Use case
+    ///
+    /// Encoder quantization loops: precompute the reference once, then in each iteration
+    /// call this to get both a global quality score (for convergence) and a spatial error
+    /// map (for per-block quant field adjustment).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZensimError::ImageTooSmall`] if dimensions < 8×8.
+    pub fn compute_with_ref_and_diffmap(
+        &self,
+        precomputed: &PrecomputedReference,
+        distorted: &impl ImageSource,
+        options: impl Into<DiffmapOptions>,
+    ) -> Result<DiffmapResult, ZensimError> {
+        let options = options.into();
+        let params = self.profile().params();
+        if distorted.width() < 8 || distorted.height() < 8 {
+            return Err(ZensimError::ImageTooSmall);
+        }
+
+        let width = distorted.width();
+        let height = distorted.height();
+        let config = config_from_params(params, self.parallel());
+        let (per_scale_ch, scale_blend) = options.weighting.resolve_multiscale(
+            params.weights,
+            config.num_scales,
+            options.include_edge_mse,
+        );
+
+        // Fused: compute the full zensim score AND the multi-scale diffmap in a
+        // single pipeline. Each scale's SSIM error is collected, then coarser
+        // scales are upsampled and blended with trained scale weights.
+        let (result, diffmap_padded, padded_width) =
+            crate::streaming::compute_zensim_streaming_with_ref_and_diffmap(
+                precomputed,
+                distorted,
+                &config,
+                params.weights,
+                &per_scale_ch,
+                &scale_blend,
+            );
+        let result = result.with_profile(self.profile());
+
+        // Trim padded-width diffmap to actual width
+        let mut diffmap = if padded_width == width {
+            diffmap_padded
+        } else {
+            let mut out = Vec::with_capacity(width * height);
+            for y in 0..height {
+                out.extend_from_slice(&diffmap_padded[y * padded_width..y * padded_width + width]);
+            }
+            out
+        };
+
+        // Post-processing: contrast masking
+        if let Some(strength) = options.masking_strength {
+            apply_contrast_masking(
+                &mut diffmap,
+                precomputed,
+                width,
+                height,
+                padded_width,
+                strength,
+            );
+        }
+
+        // Post-processing: sqrt for distance-like calibration
+        if options.sqrt {
+            for v in diffmap.iter_mut() {
+                *v = v.sqrt();
+            }
+        }
+
+        Ok(DiffmapResult {
+            result,
+            diffmap,
+            width,
+            height,
+        })
+    }
+
+    /// Compare two images and return both score and per-pixel error map.
+    ///
+    /// Convenience method that handles precomputation internally.
+    /// For iterative use (encoder loops), prefer `precompute_reference` +
+    /// `compute_with_ref_and_diffmap` to avoid re-converting the reference each time.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ZensimError`] if dimensions are mismatched or too small.
+    pub fn compute_with_diffmap(
+        &self,
+        source: &impl ImageSource,
+        distorted: &impl ImageSource,
+        options: impl Into<DiffmapOptions>,
+    ) -> Result<DiffmapResult, ZensimError> {
+        validate_pair(source, distorted)?;
+        let precomputed = self.precompute_reference(source)?;
+        self.compute_with_ref_and_diffmap(&precomputed, distorted, options)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DiffmapWeighting;
+    use crate::{RgbSlice, ZensimProfile};
+
+    #[test]
+    fn test_diffmap_identical_images() {
+        let pixels: Vec<[u8; 3]> = (0..64)
+            .map(|i| [i as u8 * 4, 128, 255 - i as u8 * 4])
+            .collect();
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&pixels, 8, 8);
+        let result = z
+            .compute_with_diffmap(&src, &src, DiffmapWeighting::default())
+            .unwrap();
+        assert_eq!(result.width(), 8);
+        assert_eq!(result.height(), 8);
+        assert_eq!(result.diffmap().len(), 64);
+        // Identical images should have ~0 error everywhere.
+        // Fused blur path has minor float precision differences (~3e-5), not exact zero.
+        let max_err = result.diffmap().iter().copied().fold(0.0f32, f32::max);
+        assert!(
+            max_err < 1e-4,
+            "max diffmap error for identical images: {max_err}"
+        );
+        // Score should be very high (small images may have minor artifacts from padding)
+        assert!(result.score() > 95.0, "score: {}", result.score());
+    }
+
+    #[test]
+    fn test_diffmap_localized_error() {
+        // Create source: uniform gray
+        let src_pixels: Vec<[u8; 3]> = vec![[128, 128, 128]; 16 * 16];
+        // Create distorted: same, but with bright patch in top-left 4x4
+        let mut dst_pixels = src_pixels.clone();
+        for y in 0..4 {
+            for x in 0..4 {
+                dst_pixels[y * 16 + x] = [255, 255, 255];
+            }
+        }
+
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&src_pixels, 16, 16);
+        let dst = RgbSlice::new(&dst_pixels, 16, 16);
+        let result = z
+            .compute_with_diffmap(&src, &dst, DiffmapWeighting::Balanced)
+            .unwrap();
+        let dm = result.diffmap();
+
+        assert_eq!(dm.len(), 256);
+        // The distorted region should have higher error than undistorted
+        let mut distorted_sum = 0.0f32;
+        for y in 0..4 {
+            for x in 0..4 {
+                distorted_sum += dm[y * 16 + x];
+            }
+        }
+        let distorted_avg = distorted_sum / 16.0;
+
+        let mut clean_sum = 0.0f32;
+        for y in 8..12 {
+            for x in 8..12 {
+                clean_sum += dm[y * 16 + x];
+            }
+        }
+        let clean_avg = clean_sum / 16.0;
+
+        assert!(
+            distorted_avg > clean_avg,
+            "distorted region avg ({distorted_avg}) should exceed clean region avg ({clean_avg})"
+        );
+    }
+
+    #[test]
+    fn test_diffmap_masking_reduces_textured_error() {
+        // Source: alternating bright/dark columns (textured)
+        let mut src_pixels: Vec<[u8; 3]> = Vec::with_capacity(16 * 16);
+        for y in 0..16 {
+            for x in 0..16 {
+                let v = if (x + y) % 2 == 0 { 200u8 } else { 60u8 };
+                src_pixels.push([v, v, v]);
+            }
+        }
+        // Distorted: shift all pixels by a fixed amount
+        let dst_pixels: Vec<[u8; 3]> = src_pixels
+            .iter()
+            .map(|p| {
+                [
+                    p[0].saturating_add(30),
+                    p[1].saturating_add(30),
+                    p[2].saturating_add(30),
+                ]
+            })
+            .collect();
+
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&src_pixels, 16, 16);
+        let dst = RgbSlice::new(&dst_pixels, 16, 16);
+
+        // Without masking
+        let raw = z
+            .compute_with_diffmap(&src, &dst, DiffmapWeighting::Balanced)
+            .unwrap();
+        let raw_max = raw.diffmap().iter().copied().fold(0.0f32, f32::max);
+
+        // With masking
+        let masked = z
+            .compute_with_diffmap(
+                &src,
+                &dst,
+                super::DiffmapOptions {
+                    weighting: DiffmapWeighting::Balanced,
+                    masking_strength: Some(4.0),
+                    sqrt: false,
+                    include_edge_mse: false,
+                },
+            )
+            .unwrap();
+        let masked_max = masked.diffmap().iter().copied().fold(0.0f32, f32::max);
+
+        // Masking should reduce error in textured content
+        assert!(
+            masked_max < raw_max,
+            "masked max ({masked_max}) should be less than raw max ({raw_max})"
+        );
+        // Scores should match (masking is post-processing, doesn't affect score)
+        assert!(
+            (raw.score() - masked.score()).abs() < 0.01,
+            "scores should match: raw {} vs masked {}",
+            raw.score(),
+            masked.score()
+        );
+    }
+
+    #[test]
+    fn test_diffmap_sqrt_compresses_range() {
+        let src_pixels: Vec<[u8; 3]> = vec![[128, 128, 128]; 16 * 16];
+        let mut dst_pixels = src_pixels.clone();
+        for y in 0..4 {
+            for x in 0..4 {
+                dst_pixels[y * 16 + x] = [255, 255, 255];
+            }
+        }
+
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&src_pixels, 16, 16);
+        let dst = RgbSlice::new(&dst_pixels, 16, 16);
+
+        let raw = z
+            .compute_with_diffmap(&src, &dst, DiffmapWeighting::Balanced)
+            .unwrap();
+        let raw_max = raw.diffmap().iter().copied().fold(0.0f32, f32::max);
+
+        let sqrted = z
+            .compute_with_diffmap(
+                &src,
+                &dst,
+                super::DiffmapOptions {
+                    weighting: DiffmapWeighting::Balanced,
+                    masking_strength: None,
+                    sqrt: true,
+                    include_edge_mse: false,
+                },
+            )
+            .unwrap();
+        let sqrt_max = sqrted.diffmap().iter().copied().fold(0.0f32, f32::max);
+
+        // sqrt(x) < x for x > 1, sqrt(x) > x for 0 < x < 1
+        // For our diffmap values (typically < 1), sqrt expands small values but
+        // the max should equal sqrt(raw_max) which for values < 1 is > raw_max
+        // For values > 1, sqrt compresses. Either way, sqrt(max) != max.
+        let expected_sqrt_max = raw_max.sqrt();
+        assert!(
+            (sqrt_max - expected_sqrt_max).abs() < 1e-5,
+            "sqrt max ({sqrt_max}) should equal sqrt(raw_max) = {expected_sqrt_max}"
+        );
+    }
+
+    #[test]
+    fn test_diffmap_weighting_into_options() {
+        // Verify backward compatibility: DiffmapWeighting converts to DiffmapOptions
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let pixels: Vec<[u8; 3]> = vec![[100, 150, 200]; 8 * 8];
+        let src = RgbSlice::new(&pixels, 8, 8);
+
+        // All three weighting variants should work via Into<DiffmapOptions>
+        let _ = z
+            .compute_with_diffmap(&src, &src, DiffmapWeighting::Trained)
+            .unwrap();
+        let _ = z
+            .compute_with_diffmap(&src, &src, DiffmapWeighting::Balanced)
+            .unwrap();
+        let _ = z
+            .compute_with_diffmap(&src, &src, DiffmapWeighting::Custom([0.3, 0.5, 0.2]))
+            .unwrap();
+    }
+
+    #[test]
+    fn test_diffmap_edge_mse_produces_valid_signal() {
+        // Edge/MSE features should produce valid non-negative per-pixel values
+        let src_pixels: Vec<[u8; 3]> = vec![[128, 128, 128]; 16 * 16];
+        let mut dst_pixels = src_pixels.clone();
+        // Create a sharp edge (high edge artifact)
+        for y in 0..8 {
+            for x in 0..16 {
+                dst_pixels[y * 16 + x] = [200, 200, 200];
+            }
+        }
+
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&src_pixels, 16, 16);
+        let dst = RgbSlice::new(&dst_pixels, 16, 16);
+
+        let with_edge = z
+            .compute_with_diffmap(
+                &src,
+                &dst,
+                super::DiffmapOptions {
+                    weighting: DiffmapWeighting::Balanced,
+                    masking_strength: None,
+                    sqrt: false,
+                    include_edge_mse: true,
+                },
+            )
+            .unwrap();
+
+        // All values should be non-negative
+        assert!(
+            with_edge.diffmap().iter().all(|&v| v >= 0.0),
+            "all diffmap values should be non-negative"
+        );
+        // Should have signal (not all zeros)
+        let max = with_edge.diffmap().iter().copied().fold(0.0f32, f32::max);
+        assert!(max > 0.0, "max should be > 0 for distorted image");
+        // Distorted half should have higher error than clean half
+        let top_avg: f32 = with_edge.diffmap()[..128].iter().sum::<f32>() / 128.0;
+        let bot_avg: f32 = with_edge.diffmap()[128..].iter().sum::<f32>() / 128.0;
+        assert!(
+            top_avg > bot_avg,
+            "distorted region ({top_avg}) should exceed clean region ({bot_avg})"
+        );
+        // Scores should match (feature inclusion is diffmap-only)
+        let ssim_only = z
+            .compute_with_diffmap(&src, &dst, DiffmapWeighting::Balanced)
+            .unwrap();
+        assert!(
+            (ssim_only.score() - with_edge.score()).abs() < 0.01,
+            "scores should match: {} vs {}",
+            ssim_only.score(),
+            with_edge.score()
+        );
+    }
+
+    #[test]
+    fn test_diffmap_edge_mse_trained_weights() {
+        // Trained weighting with edge/MSE should produce valid results
+        let src_pixels: Vec<[u8; 3]> = (0..256).map(|i| [(i % 256) as u8, 128, 64]).collect();
+        let mut dst_pixels = src_pixels.clone();
+        for p in dst_pixels[..64].iter_mut() {
+            p[0] = p[0].wrapping_add(40);
+        }
+
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&src_pixels, 16, 16);
+        let dst = RgbSlice::new(&dst_pixels, 16, 16);
+
+        let result = z
+            .compute_with_diffmap(
+                &src,
+                &dst,
+                super::DiffmapOptions {
+                    weighting: DiffmapWeighting::Trained,
+                    masking_strength: None,
+                    sqrt: false,
+                    include_edge_mse: true,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(result.diffmap().len(), 256);
+        // All values should be non-negative
+        assert!(
+            result.diffmap().iter().all(|&v| v >= 0.0),
+            "all diffmap values should be non-negative"
+        );
+        // At least some values should be > 0 (we have distortion)
+        let max = result.diffmap().iter().copied().fold(0.0f32, f32::max);
+        assert!(max > 0.0, "max diffmap value should be > 0");
+    }
+
+    #[test]
+    fn test_diffmap_with_precomputed_ref() {
+        let pixels: Vec<[u8; 3]> = (0..256).map(|i| [(i % 256) as u8, 128, 64]).collect();
+        let mut dst = pixels.clone();
+        // Perturb some pixels
+        for p in dst[..32].iter_mut() {
+            p[0] = p[0].wrapping_add(50);
+        }
+
+        let z = crate::Zensim::new(ZensimProfile::latest());
+        let src = RgbSlice::new(&pixels, 16, 16);
+        let dst = RgbSlice::new(&dst, 16, 16);
+
+        let precomputed = z.precompute_reference(&src).unwrap();
+        let result = z
+            .compute_with_ref_and_diffmap(&precomputed, &dst, DiffmapWeighting::Trained)
+            .unwrap();
+
+        assert_eq!(result.width(), 16);
+        assert_eq!(result.height(), 16);
+        // Score should match regular compute
+        let regular = z.compute_with_ref(&precomputed, &dst).unwrap();
+        assert!(
+            (result.score() - regular.score()).abs() < 0.01,
+            "diffmap score {} vs regular score {}",
+            result.score(),
+            regular.score()
+        );
+    }
+}

--- a/zensim/src/fused.rs
+++ b/zensim/src/fused.rs
@@ -97,6 +97,8 @@ pub(crate) fn fused_vblur_features_ssim(
     mu1_out: &mut [f32],
     mu2_out: &mut [f32],
     store_mu: bool,
+    sd_out: &mut [f32],
+    store_sd: bool,
 ) -> StripChannelAccum {
     incant!(
         fused_vblur_ssim_inner(
@@ -113,7 +115,9 @@ pub(crate) fn fused_vblur_features_ssim(
             radius,
             mu1_out,
             mu2_out,
-            store_mu
+            store_mu,
+            sd_out,
+            store_sd
         ),
         [v4, v3]
     )
@@ -216,6 +220,8 @@ fn fused_vblur_ssim_inner_v4(
     mu1_out: &mut [f32],
     mu2_out: &mut [f32],
     store_mu: bool,
+    sd_out: &mut [f32],
+    store_sd: bool,
 ) -> StripChannelAccum {
     let diam = 2 * radius + 1;
     let inv_v = f32x16::splat(token, 1.0 / diam as f32);
@@ -279,6 +285,9 @@ fn fused_vblur_ssim_inner_v4(
                 acc.ssim_d2 += sd2.reduce_add() as f64;
                 acc.ssim_d8 += (sd4 * sd4).reduce_add() as f64;
                 acc.ssim_max = acc.ssim_max.max(sd.reduce_max());
+                if store_sd {
+                    sd_out[base..base + 16].copy_from_slice(&sd.to_array());
+                }
                 if store_mu {
                     mu1_out[base..base + 16].copy_from_slice(&mu1.to_array());
                     mu2_out[base..base + 16].copy_from_slice(&mu2.to_array());
@@ -392,6 +401,9 @@ fn fused_vblur_ssim_inner_v4(
                 acc.ssim_d2 += sd2.reduce_add() as f64;
                 acc.ssim_d8 += (sd4 * sd4).reduce_add() as f64;
                 acc.ssim_max = acc.ssim_max.max(sd.reduce_max());
+                if store_sd {
+                    sd_out[base..base + 8].copy_from_slice(&sd.to_array());
+                }
                 if store_mu {
                     mu1_out[base..base + 8].copy_from_slice(&mu1.to_array());
                     mu2_out[base..base + 8].copy_from_slice(&mu2.to_array());
@@ -488,6 +500,9 @@ fn fused_vblur_ssim_inner_v4(
                 acc.ssim_d2 += sd2 as f64;
                 acc.ssim_d8 += (sd4 * sd4) as f64;
                 acc.ssim_max = acc.ssim_max.max(sd);
+                if store_sd {
+                    sd_out[y * width + x] = sd;
+                }
                 if store_mu {
                     mu1_out[y * width + x] = mu1;
                     mu2_out[y * width + x] = mu2;
@@ -563,6 +578,8 @@ fn fused_vblur_ssim_inner_v3(
     mu1_out: &mut [f32],
     mu2_out: &mut [f32],
     store_mu: bool,
+    sd_out: &mut [f32],
+    store_sd: bool,
 ) -> StripChannelAccum {
     let diam = 2 * radius + 1;
     let inv_v = f32x8::splat(token, 1.0 / diam as f32);
@@ -617,6 +634,9 @@ fn fused_vblur_ssim_inner_v3(
                 acc.ssim_d2 += sd2.reduce_add() as f64;
                 acc.ssim_d8 += (sd4 * sd4).reduce_add() as f64;
                 acc.ssim_max = acc.ssim_max.max(sd.reduce_max());
+                if store_sd {
+                    sd_out[base..base + 8].copy_from_slice(&sd.to_array());
+                }
                 if store_mu {
                     mu1_out[base..base + 8].copy_from_slice(&mu1.to_array());
                     mu2_out[base..base + 8].copy_from_slice(&mu2.to_array());
@@ -713,6 +733,9 @@ fn fused_vblur_ssim_inner_v3(
                 acc.ssim_d2 += sd2 as f64;
                 acc.ssim_d8 += (sd4 * sd4) as f64;
                 acc.ssim_max = acc.ssim_max.max(sd);
+                if store_sd {
+                    sd_out[y * width + x] = sd;
+                }
                 if store_mu {
                     mu1_out[y * width + x] = mu1;
                     mu2_out[y * width + x] = mu2;
@@ -786,6 +809,8 @@ fn fused_vblur_ssim_inner_scalar(
     mu1_out: &mut [f32],
     mu2_out: &mut [f32],
     store_mu: bool,
+    sd_out: &mut [f32],
+    store_sd: bool,
 ) -> StripChannelAccum {
     let diam = 2 * radius + 1;
     let inv = 1.0 / diam as f32;
@@ -830,6 +855,9 @@ fn fused_vblur_ssim_inner_scalar(
                 acc.ssim_d2 += sd2 as f64;
                 acc.ssim_d8 += (sd4 * sd4) as f64;
                 acc.ssim_max = acc.ssim_max.max(sd);
+                if store_sd {
+                    sd_out[y * width + x] = sd;
+                }
                 if store_mu {
                     mu1_out[y * width + x] = mu1;
                     mu2_out[y * width + x] = mu2;

--- a/zensim/src/lib.rs
+++ b/zensim/src/lib.rs
@@ -100,6 +100,7 @@
 
 mod blur;
 mod color;
+mod diffmap;
 mod error;
 mod fused;
 pub mod mapping;
@@ -130,6 +131,7 @@ pub use source::{
     AlphaMode, ColorPrimaries, ImageSource, PixelFormat, RgbSlice, RgbaSlice, StridedBytes,
 };
 
+pub use diffmap::{DiffmapOptions, DiffmapResult, DiffmapWeighting};
 pub use streaming::PrecomputedReference;
 
 /// Training/research API — requires `features = ["training"]`.

--- a/zensim/src/metric.rs
+++ b/zensim/src/metric.rs
@@ -250,10 +250,7 @@ pub struct ZensimConfig {
     /// high-quality range.
     pub score_mapping_b: f64,
 
-    /// Whether to use rayon parallelism (default: true).
-    ///
-    /// When false, all computation runs on the current thread — useful for
-    /// benchmarking single-threaded performance or embedding in async contexts.
+    /// Enable multi-threaded computation via rayon (default: true).
     pub allow_multithreading: bool,
 }
 
@@ -766,7 +763,7 @@ pub struct Zensim {
 }
 
 impl Zensim {
-    /// Create a new `Zensim` with the given profile.
+    /// Create a new `Zensim` with the given profile. Parallel by default.
     pub fn new(profile: ZensimProfile) -> Self {
         Self {
             profile,
@@ -774,23 +771,21 @@ impl Zensim {
         }
     }
 
-    /// Enable or disable rayon parallelism (default: enabled).
-    ///
-    /// When disabled, all computation runs on the current thread.
-    #[must_use]
+    /// Enable or disable multi-threaded computation (rayon).
+    /// Default: `true`.
     pub fn with_parallel(mut self, parallel: bool) -> Self {
         self.parallel = parallel;
         self
     }
 
-    /// Whether rayon parallelism is enabled.
-    pub fn parallel(&self) -> bool {
-        self.parallel
-    }
-
     /// Current profile.
     pub fn profile(&self) -> ZensimProfile {
         self.profile
+    }
+
+    /// Whether multi-threaded computation is enabled.
+    pub fn parallel(&self) -> bool {
+        self.parallel
     }
 
     /// Compare source and distorted images.
@@ -1083,7 +1078,7 @@ fn compute_rounding_bias(delta_stats: &DeltaStats) -> RoundingBias {
     }
 }
 
-fn validate_pair(
+pub(crate) fn validate_pair(
     source: &impl ImageSource,
     distorted: &impl ImageSource,
 ) -> Result<(), ZensimError> {

--- a/zensim/src/streaming.rs
+++ b/zensim/src/streaming.rs
@@ -13,6 +13,7 @@ use crate::color::{
     composite_srgb8_rgba_to_linear, composite_srgb16_rgba_to_linear,
     linear_to_positive_xyb_planar_into, srgb_to_positive_xyb_planar_into,
 };
+use crate::diffmap::PixelFeatureWeights;
 use crate::fused::{fused_vblur_features_edge, fused_vblur_features_ssim};
 use crate::metric::{FEATURES_PER_CHANNEL_BASIC, ScaleStats, ZensimConfig, combine_scores};
 use crate::pool::ScaleBuffers;
@@ -52,7 +53,7 @@ fn downscale_3_planes(
     h: usize,
     parallel: bool,
 ) -> (usize, usize) {
-    let [p0, p1, p2] = planes;
+    let [ref mut p0, ref mut p1, ref mut p2] = *planes;
     let (nw_nh, _) = maybe_join(
         parallel,
         || downscale_2x_inplace(p0, w, h),
@@ -81,6 +82,41 @@ fn downscale_6_planes(
         || downscale_3_planes(dst, w, h, parallel),
     );
     nw_nh
+}
+
+/// Upsample a 2D buffer by 2x (nearest-neighbor) and add to `dst` with a weight.
+///
+/// `src` is `src_w × src_h` elements (row-major), `dst` is `dst_w × dst_h` elements.
+/// Each source pixel maps to a 2×2 block in the destination.
+/// Handles edge cases where `dst` dimensions are odd (2*src_w-1 or 2*src_h-1).
+fn upsample_2x_add(
+    src: &[f32],
+    src_w: usize,
+    src_h: usize,
+    dst: &mut [f32],
+    dst_w: usize,
+    dst_h: usize,
+    weight: f32,
+) {
+    for sy in 0..src_h {
+        let dy0 = sy * 2;
+        let dy1 = (dy0 + 1).min(dst_h - 1);
+        for sx in 0..src_w {
+            let dx0 = sx * 2;
+            let dx1 = (dx0 + 1).min(dst_w - 1);
+            let val = src[sy * src_w + sx] * weight;
+            dst[dy0 * dst_w + dx0] += val;
+            if dx1 < dst_w {
+                dst[dy0 * dst_w + dx1] += val;
+            }
+            if dy1 < dst_h {
+                dst[dy1 * dst_w + dx0] += val;
+                if dx1 < dst_w {
+                    dst[dy1 * dst_w + dx1] += val;
+                }
+            }
+        }
+    }
 }
 
 /// Track background deallocation thread to prevent accumulation on repeated calls.
@@ -389,7 +425,7 @@ pub(crate) fn compute_multiscale_stats_streaming(
     let num_scales = config.num_scales;
     let parallel = config.allow_multithreading;
 
-    // Phase 1: Convert sRGB→XYB for entire image, parallel over row chunks.
+    // Phase 1: Convert sRGB→XYB for entire image.
     let mut src_planes = convert_source_to_xyb(source, padded_width, parallel);
     let mut dst_planes = convert_source_to_xyb(distorted, padded_width, parallel);
 
@@ -397,8 +433,7 @@ pub(crate) fn compute_multiscale_stats_streaming(
     let mean_offset =
         compute_xyb_mean_offset(&src_planes, &dst_planes, width, height, padded_width);
 
-    // Phase 2: Process all scales with parallel band processing.
-    // Each scale: compute features in parallel bands, then downscale planes for next scale.
+    // Phase 2: Process all scales with band processing.
     let mut stats = Vec::with_capacity(num_scales);
     let mut w = padded_width;
     let mut h = height;
@@ -408,12 +443,10 @@ pub(crate) fn compute_multiscale_stats_streaming(
             break;
         }
 
-        // Parallel band processing: borrow slices from full planes
-        let scale_stat =
-            process_scale_bands(&src_planes, &dst_planes, w, h, config, scale, weights);
+        let (scale_stat, _) =
+            process_scale_bands(&src_planes, &dst_planes, w, h, config, scale, weights, None);
         stats.push(scale_stat);
 
-        // Downscale 6 planes for next scale
         if scale < num_scales - 1 {
             let (nw, nh) = downscale_6_planes(&mut src_planes, &mut dst_planes, w, h, parallel);
             w = nw;
@@ -421,9 +454,8 @@ pub(crate) fn compute_multiscale_stats_streaming(
         }
     }
 
-    // Background deallocation: move ~400MB of XYB planes to a background thread
-    // to avoid blocking on munmap syscalls (which take ~57ms on WSL for this volume).
-    // Track the thread to prevent accumulation on repeated calls.
+    // Background deallocation: move XYB planes to a background thread
+    // to avoid blocking on munmap syscalls.
     {
         let mut guard = DEALLOC_THREAD.lock().unwrap();
         if let Some(prev) = guard.take() {
@@ -788,6 +820,7 @@ fn process_strip_channel(
     need_edge: bool,
     bufs: &mut ScaleBuffers,
     accum: &mut ScaleAccumulators,
+    mut diffmap: Option<(&mut [f32], PixelFeatureWeights)>,
 ) {
     // MSE-only path: no blur needed
     if !need_ssim && !need_edge {
@@ -804,6 +837,10 @@ fn process_strip_channel(
     if config.blur_passes == 1 {
         let strip_acc;
 
+        let dm_needs_edge = diffmap.as_ref().is_some_and(|(_, pw)| pw.needs_edge_mse());
+        let store_sd = diffmap.is_some() && need_ssim;
+        // Force mu1/mu2 storage when diffmap needs edge/MSE features
+        let store_mu = config.extended_features || dm_needs_edge;
         if need_ssim {
             // Fused H-blur: src,dst → 4 H-blurred planes in one pass
             fused_blur_h_ssim(
@@ -820,6 +857,8 @@ fn process_strip_channel(
 
             // Fused V-blur + ALL feature extraction
             // mu1/mu2 outputs go to mask/mul_buf (mu1/mu2 still hold H-blurred values)
+            // sd_out goes to temp_blur (only used when store_sd=true, extracted before
+            // extended features which also need temp_blur for blurs)
             strip_acc = fused_vblur_features_ssim(
                 &bufs.mu1,
                 &bufs.mu2,
@@ -834,8 +873,41 @@ fn process_strip_channel(
                 config.blur_radius,
                 &mut bufs.mask,
                 &mut bufs.mul_buf,
-                config.extended_features,
+                store_mu,
+                &mut bufs.temp_blur,
+                store_sd,
             );
+
+            // Accumulate weighted features into diffmap before extended features
+            // overwrites temp_blur. Inner rows are at inner_start..inner_start+inner_h
+            // in strip-local coordinates.
+            //
+            // When edge/MSE is enabled, mu1 is in bufs.mask and mu2 is in bufs.mul_buf
+            // (written by fused kernel when store_mu=true, not yet swapped).
+            if let Some((ref mut dm, pw)) = diffmap {
+                let inner_off = inner_start * width;
+                let inner_n = inner_h * width;
+                if dm_needs_edge {
+                    for i in 0..inner_n {
+                        let idx = inner_off + i;
+                        let mut val = pw.ssim * bufs.temp_blur[idx];
+                        // Edge features from mu1/mu2 (in mask/mul_buf before swap)
+                        let res_src = src_c[idx] - bufs.mask[idx];
+                        let res_dst = dst_c[idx] - bufs.mul_buf[idx];
+                        let edge_diff = res_dst * res_dst - res_src * res_src;
+                        val += pw.art * edge_diff.max(0.0);
+                        val += pw.det * (-edge_diff).max(0.0);
+                        // MSE
+                        let d = src_c[idx] - dst_c[idx];
+                        val += pw.mse * d * d;
+                        dm[i] += val;
+                    }
+                } else {
+                    for i in 0..inner_n {
+                        dm[i] += pw.ssim * bufs.temp_blur[inner_off + i];
+                    }
+                }
+            }
 
             accum.ssim_d[c] += strip_acc.ssim_d;
             accum.ssim_d4[c] += strip_acc.ssim_d4;
@@ -1128,6 +1200,7 @@ fn process_strip_channel(
 ///
 /// Divides the image into horizontal bands, each processing sequential strips.
 /// Each band runs on a separate thread via rayon.
+#[allow(clippy::too_many_arguments)]
 fn process_scale_bands(
     src_planes: &[Vec<f32>; 3],
     dst_planes: &[Vec<f32>; 3],
@@ -1136,7 +1209,8 @@ fn process_scale_bands(
     config: &ZensimConfig,
     scale_idx: usize,
     weights: &[f64],
-) -> ScaleStats {
+    diffmap_weights: Option<[PixelFeatureWeights; 3]>,
+) -> (ScaleStats, Option<Vec<f32>>) {
     let r = config.blur_radius;
     let passes = config.blur_passes as usize;
     let overlap = passes * r;
@@ -1154,13 +1228,16 @@ fn process_scale_bands(
     let max_strip_h = STRIP_INNER + 2 * overlap;
     let max_strip_n = max_strip_h * width;
 
-    let band_work = |band_idx: usize| {
+    let process_band = |band_idx: usize| {
         let band_first_y = (band_idx * strips_per_band * STRIP_INNER).min(height);
         let band_end_y = (((band_idx + 1) * strips_per_band) * STRIP_INNER).min(height);
 
         if band_first_y >= height {
-            return ScaleAccumulators::new();
+            return (ScaleAccumulators::new(), None);
         }
+
+        let band_rows = band_end_y - band_first_y;
+        let mut band_dm = diffmap_weights.map(|_| vec![0.0f32; band_rows * width]);
 
         let mut accum = ScaleAccumulators::new();
         let mut bufs = ScaleBuffers::new(max_strip_n);
@@ -1180,7 +1257,18 @@ fn process_scale_bands(
 
             accum.n += inner_h * width;
 
+            // Diffmap slice for this strip's inner rows (band-local offset)
+            let dm_start = (y - band_first_y) * width;
+            let dm_n = inner_h * width;
+
             for &(c, need_ssim, need_edge) in &scale_active {
+                let dm_info = match band_dm.as_mut() {
+                    Some(dm) if need_ssim => {
+                        let dm_w = diffmap_weights.unwrap();
+                        Some((&mut dm[dm_start..dm_start + dm_n], dm_w[c]))
+                    }
+                    _ => None,
+                };
                 process_strip_channel(
                     &src_planes[c][strip_top * width..strip_bot * width],
                     &dst_planes[c][strip_top * width..strip_bot * width],
@@ -1194,27 +1282,40 @@ fn process_scale_bands(
                     need_edge,
                     &mut bufs,
                     &mut accum,
+                    dm_info,
                 );
             }
 
             y = inner_end;
         }
 
-        accum
+        (accum, band_dm)
     };
 
-    let band_accums: Vec<_> = if parallel {
-        (0..num_bands).into_par_iter().map(band_work).collect()
+    #[allow(clippy::redundant_closure)]
+    let band_results: Vec<_> = if parallel {
+        (0..num_bands)
+            .into_par_iter()
+            .map(|i| process_band(i))
+            .collect()
     } else {
-        (0..num_bands).map(band_work).collect()
+        (0..num_bands).map(|i| process_band(i)).collect()
     };
 
-    // Merge band accumulators
+    // Merge band accumulators and concatenate diffmaps
     let mut accum = ScaleAccumulators::new();
-    for band_accum in band_accums {
+    let mut diffmap = if diffmap_weights.is_some() {
+        Some(Vec::with_capacity(width * height))
+    } else {
+        None
+    };
+    for (band_accum, band_dm) in band_results {
         accum.merge(&band_accum);
+        if let (Some(dm), Some(bdm)) = (&mut diffmap, band_dm) {
+            dm.extend_from_slice(&bdm);
+        }
     }
-    accum.finalize()
+    (accum.finalize(), diffmap)
 }
 
 /// Pre-computed reference image data for batch comparison against multiple distorted images.
@@ -1254,10 +1355,8 @@ impl PrecomputedReference {
                 break;
             }
 
-            // Clone and store planes at this scale
             scales.push((planes.clone(), w, h));
 
-            // Downscale for next scale
             if scale < num_scales - 1 {
                 let (nw, nh) = downscale_3_planes(&mut planes, w, h, parallel);
                 w = nw;
@@ -1307,10 +1406,10 @@ pub(crate) fn compute_multiscale_stats_streaming_with_ref(
         debug_assert_eq!(w, src_w, "width mismatch at scale {scale}");
         debug_assert_eq!(h, src_h, "height mismatch at scale {scale}");
 
-        let scale_stat = process_scale_bands(src_planes, &dst_planes, w, h, config, scale, weights);
+        let (scale_stat, _) =
+            process_scale_bands(src_planes, &dst_planes, w, h, config, scale, weights, None);
         stats.push(scale_stat);
 
-        // Only downscale the 3 distorted planes for next scale
         if scale < num_scales - 1 {
             let (nw, nh) = downscale_3_planes(&mut dst_planes, w, h, parallel);
             w = nw;
@@ -1345,6 +1444,136 @@ pub(crate) fn compute_zensim_streaming_with_ref(
     combine_scores(&scale_stats, weights, config, mean_offset)
 }
 
+/// Like `compute_zensim_streaming_with_ref`, but also produces a per-pixel error
+/// diffmap fused from all pyramid scales.
+///
+/// Each scale's SSIM error map is weighted by per-scale channel weights, then
+/// coarser scales are upsampled 2× (nearest-neighbor) back to full resolution
+/// and blended according to `scale_blend_weights`.
+///
+/// Returns `(ZensimResult, diffmap_padded, padded_width)` where `diffmap_padded`
+/// has `padded_width × height` elements in padded-width row layout.
+pub(crate) fn compute_zensim_streaming_with_ref_and_diffmap(
+    precomputed: &PrecomputedReference,
+    distorted: &impl ImageSource,
+    config: &ZensimConfig,
+    weights: &[f64],
+    per_scale_channel_weights: &[[PixelFeatureWeights; 3]],
+    scale_blend_weights: &[f32],
+) -> (crate::metric::ZensimResult, Vec<f32>, usize) {
+    let width = distorted.width();
+    let height = distorted.height();
+    let padded_width = simd_padded_width(width);
+    let num_scales = config.num_scales.min(precomputed.scales.len());
+
+    let parallel = config.allow_multithreading;
+    let mut dst_planes = convert_source_to_xyb(distorted, padded_width, parallel);
+
+    let (ref src_planes_s0, _, _) = precomputed.scales[0];
+    let mean_offset =
+        compute_xyb_mean_offset(src_planes_s0, &dst_planes, width, height, padded_width);
+
+    let mut stats = Vec::with_capacity(num_scales);
+    // Collect per-scale diffmaps with their dimensions
+    let mut scale_diffmaps: Vec<(Vec<f32>, usize, usize)> = Vec::with_capacity(num_scales);
+    let mut w = padded_width;
+    let mut h = height;
+
+    for scale in 0..num_scales {
+        if w < 8 || h < 8 {
+            break;
+        }
+
+        let (ref src_planes, src_w, src_h) = precomputed.scales[scale];
+        debug_assert_eq!(w, src_w, "width mismatch at scale {scale}");
+        debug_assert_eq!(h, src_h, "height mismatch at scale {scale}");
+
+        // Request diffmap at every scale
+        let eq = PixelFeatureWeights {
+            ssim: 1.0 / 3.0,
+            ..PixelFeatureWeights::default()
+        };
+        let ch_weights = per_scale_channel_weights
+            .get(scale)
+            .copied()
+            .unwrap_or([eq; 3]);
+        let (scale_stat, dm) = process_scale_bands(
+            src_planes,
+            &dst_planes,
+            w,
+            h,
+            config,
+            scale,
+            weights,
+            Some(ch_weights),
+        );
+        stats.push(scale_stat);
+
+        if let Some(dm) = dm {
+            scale_diffmaps.push((dm, w, h));
+        }
+
+        if scale < num_scales - 1 {
+            let (nw, nh) = downscale_3_planes(&mut dst_planes, w, h, parallel);
+            w = nw;
+            h = nh;
+        }
+    }
+
+    {
+        let mut guard = DEALLOC_THREAD.lock().unwrap();
+        if let Some(prev) = guard.take() {
+            let _ = prev.join();
+        }
+        *guard = Some(std::thread::spawn(move || {
+            drop(dst_planes);
+        }));
+    }
+
+    // Fuse multi-scale diffmaps: scale 0 at full weight, coarser scales upsampled and blended
+    let full_w = padded_width;
+    let full_h = height;
+    let mut fused = vec![0.0f32; full_w * full_h];
+
+    for (scale, (dm, dm_w, dm_h)) in scale_diffmaps.iter().enumerate() {
+        let blend = scale_blend_weights.get(scale).copied().unwrap_or(0.0);
+        if blend <= 0.0 {
+            continue;
+        }
+        if scale == 0 {
+            // Scale 0 is already at full resolution — just add weighted
+            for (d, &s) in fused.iter_mut().zip(dm.iter()) {
+                *d += s * blend;
+            }
+        } else {
+            // Upsample coarser scale back to full resolution
+            // Each scale level is 2x smaller, so upsample `scale` times
+            let mut current = dm.clone();
+            let mut cw = *dm_w;
+            let mut ch = *dm_h;
+            for _ in 0..scale {
+                let tw = (cw * 2).min(full_w);
+                let th = (ch * 2).min(full_h);
+                let mut upsampled = vec![0.0f32; tw * th];
+                upsample_2x_add(&current, cw, ch, &mut upsampled, tw, th, 1.0);
+                current = upsampled;
+                cw = tw;
+                ch = th;
+            }
+            // Add to fused (dimensions should match or be close)
+            let copy_w = cw.min(full_w);
+            let copy_h = ch.min(full_h);
+            for y in 0..copy_h {
+                for x in 0..copy_w {
+                    fused[y * full_w + x] += current[y * cw + x] * blend;
+                }
+            }
+        }
+    }
+
+    let result = combine_scores(&stats, weights, config, mean_offset);
+    (result, fused, padded_width)
+}
 /// Entry point: compute zensim using streaming for scale 0, full-image for the rest.
 /// Produces identical results to the full-image path.
 pub(crate) fn compute_zensim_streaming(


### PR DESCRIPTION
## Summary

Adds a per-pixel perceptual error map (diffmap) API to zensim, designed for encoder quantization loops. The diffmap tells you WHERE quality is lost, while the global score tells you HOW MUCH.

Based on `bench-and-parallel` (threading control + benchmark infrastructure).

- **Per-pixel SSIM error map** fused into the main scoring pipeline at zero overhead — no extra blur passes or XYB conversions
- **Multi-scale fusion**: SSIM maps from all 4 pyramid scales upsampled to full resolution and blended with trained scale weights (s0 ~6%, s1-s3 ~28-35%)
- **Edge artifact + detail loss + MSE features** (opt-in via `include_edge_mse`) — per-pixel edge structure added/removed by distortion, plus raw MSE, weighted by trained per-feature weights
- **Contrast masking** (opt-in via `masking_strength`) — suppresses error in textured regions using source luminance variance
- **Sqrt calibration** (opt-in via `sqrt`) — compresses dynamic range for distance-like scaling

### API

```rust
let z = Zensim::new(ZensimProfile::latest());
let precomputed = z.precompute_reference(&source)?;

// SSIM-only (default, backward compatible)
let result = z.compute_with_ref_and_diffmap(&precomputed, &distorted, DiffmapWeighting::Trained)?;

// Full features
let result = z.compute_with_ref_and_diffmap(&precomputed, &distorted, DiffmapOptions {
    weighting: DiffmapWeighting::Trained,
    masking_strength: Some(4.0),
    sqrt: true,
    include_edge_mse: true,
})?;

println!("score: {:.2}", result.score());
let error_map: &[f32] = result.diffmap(); // width × height, row-major
```

## Test plan

- [x] 44 unit tests pass (8 diffmap tests: identical, localized error, precomputed ref, masking, sqrt, edge/MSE signal, edge/MSE trained weights, backward compat)
- [x] 42 integration tests pass (cross-platform, ICC, cross-tier)
- [x] Clippy clean (`-D warnings`)
- [x] Score parity: `compute_with_diffmap` score matches `compute` score (< 0.01 delta)
- [x] Identical images produce near-zero diffmap (max < 1e-4)
- [x] Masking reduces textured-region error
- [x] Sqrt produces `sqrt(raw)` values
- [x] Edge/MSE features produce non-negative values with spatial localization