### PR TITLE
Internal layout module + diff_image refactor + safety + RenderConfig

### DIFF
--- a/regression-report.md
+++ b/regression-report.md
@@ -1,0 +1,100 @@
+# Layout-module port — regression report
+
+## Summary
+
+`render_montage_impl`, `render_mismatched_montage`, and `render_heatmap_grid`
+in `zensim-regress/src/diff_image.rs` rewritten on top of the new
+`layout` module (`src/layout.rs`).
+
+**6 of 6 regression scenes are byte-identical to the pre-port baseline.**
+**272 of 272 lib tests pass. Clippy clean.**
+
+## What changed
+
+| Function | Before | After | Notes |
+|---|---:|---:|---|
+| `render_montage_impl` (same-dim) | 290 lines | 30 lines + shared composer | composes via `compose_montage` |
+| `render_mismatched_montage` | 386 lines | ~120 lines (panel prep only) + shared composer | same composer |
+| `render_heatmap_grid` | 110 lines | 90 lines | layout `Grid` + `Layers` per cell |
+| `compose_montage` (new) | — | 165 lines | shared 2×2 grid + strip-stack |
+| `fill_rect` (private helper) | 10 lines | 0 (deleted) | layout module owns this now |
+
+`diff_image.rs` net **2232 → 1892 lines (−340)**, plus 2269 lines added in the
+new layout module. The two near-duplicate render functions are gone — they
+now share `compose_montage`. The mismatched function only owns its
+panel-prep prologue.
+
+## Regression-test scenes
+
+`zensim-regress/examples/montage_regression.rs` exercises six representative
+scenes covering both code paths and the optional annotation strips:
+
+| Scene | Dim | Annotations | Heatmap | Path | Pixels |
+|---|---|---|---|---|---|
+| 01 same-dim plain | 96×96 same | none | yes | same-dim | identical |
+| 02 same-dim annotated | 96×96 same | title + 3 primary lines + extra | yes | same-dim | identical |
+| 03 mismatched plain | 96×64 vs 72×96 | none | (no diff in plain) | mismatched | identical |
+| 04 mismatched annotated | 96×64 vs 72×96 | title + primary + extra | yes | mismatched | identical |
+| 05 tiny pixelate | 16×16 | none | yes | same-dim, pixelate-upscale | identical |
+| 06 custom labels | 96×96 | "REFERENCE-LONG-NAME" / "CANDIDATE", heatmap off | no | same-dim | identical |
+
+Compare via:
+
+```sh
+cargo run -p zensim-regress --example montage_regression -- /tmp/montage_baseline
+# (port the changes, then)
+cargo run -p zensim-regress --example montage_regression -- /tmp/montage_new
+cargo run -p zensim-regress --example montage_diff
+```
+
+## Bugs found and fixed during the port
+
+The diff-driven workflow surfaced three real bugs in the new layout
+module that the unit tests had missed (all had clean tests before — they
+were missing coverage, not broken):
+
+1. **`render_grid` clipped the last column by `gap` pixels**
+   `col_off[i+1] - gap` was applied unconditionally, but the last
+   col_off has no trailing gap. Right-most cells got `cell_w - pad`
+   instead of `cell_w`. Fixed by subtracting gap only for non-trailing
+   spans. Added a `grid_with_gap_last_col_full_width` test.
+
+2. **`Image` rendered with `Fit::None` was centered, not top-left**
+   When the rect was bigger than the image (e.g. heatmap 598 wide
+   inside a 600-wide column with `align_items: Stretch`), the image
+   got `(rect.w - img.w) / 2` left-offset. Original code expected
+   top-left placement. Fix: only center when `Fit::Contain`/`Cover`
+   are explicitly set; otherwise paint at rect's origin. Centering is
+   recoverable via `.center()`.
+
+3. **Auto-fit text char_h shifted between measure and paint**
+   `font::render_lines_fitted` derives char height from `max_w` via
+   integer arithmetic. When `Align` reduces a rect to the measured
+   natural width, paint sees a smaller `max_w` than measure did and
+   may compute a different char_h (e.g., 40 vs 39). Fix in this
+   port: pre-rasterize annotation text into `Image` leaves rather
+   than relying on `Node::Text`'s auto-fit at paint time. Plain
+   labels and ADD/REMOVE happen to hit a clamp boundary so they're
+   stable through the round-trip.
+
+These bugs would have caused subtle 1–2-px visual drift in production
+with no test signal — caught only by the byte-level regression
+comparison.
+
+## Layout-module additions/changes during the port
+
+- `LabelStyle::strip` and `LabelStyle::segmented_strip` made `pub`
+  (needed by the port to build label nodes with explicit height).
+- `LabelStyle::strip` switched from `align_h(self.align)` to
+  `align(self.align, VAlign::Center)` so labels vertically center
+  inside an over-sized strip.
+- New unit test for `Grid` with non-zero gap at the last column.
+
+## Next step (separate change)
+
+The shared `compose_montage` is right where it is for now — clean and
+self-contained. The layout module is internal to `zensim-regress`; the
+text auto-fit caveat (workaround: pre-rasterize) is the strongest
+argument for caching `char_h` inside `Node::Text` in a future iteration,
+which would make the API friendlier for non-pre-rasterized annotation
+strips. Not blocking.

--- a/zengrid-proposal.md
+++ b/zengrid-proposal.md
@@ -1,0 +1,120 @@
+# zengrid — extraction analysis
+
+Worktree: `~/work/zen/zensim--zengrid-analysis/` (jj workspace `zengrid-analysis`).
+No code edits — investigation only.
+
+## What "layout/montage" code currently lives in zensim-regress
+
+All in two files (~2.65k lines combined, ~18% of the crate):
+
+| File | Lines | Concern |
+|------|------:|---------|
+| `src/diff_image.rs` | 2232 | montage composition + diff rendering (mixed) |
+| `src/font.rs` | 419 | embedded Consolas glyph strip + text rendering |
+
+`diff_image.rs` is doing two distinct jobs glued together:
+
+1. **Diff math** — `generate_diff_image`, `generate_structural_diff`, `spatial_analysis`, `RegionStats`, `SpatialAnalysis`, `pixelate_upscale`. Fundamentally about *pixels*.
+2. **Visual layout** — `MontageOptions`, `render_montage_impl`, `render_mismatched_montage`, `render_heatmap_grid`, `create_montage`, `fill_rect`, `draw_rect_border`, deprecated `create_*_montage*` family, `AnnotationText`, label bars, title strip, primary strip, vertical stacking. Fundamentally about *boxes*.
+
+The split is clean: ~1200 lines are layout, ~1000 lines are diff. Nothing in the layout code reaches into diff internals beyond reading `RgbaImage` panels and a `SpatialAnalysis { regions, cols, rows }` struct.
+
+## The recurring shapes
+
+Reading the two big render functions, the same primitives appear over and over:
+
+| Primitive | Where it shows up |
+|-----------|-------------------|
+| **2×2 grid of cells**, each cell = label-bar + image | `render_montage_impl` lines 810–914, `render_mismatched_montage` 1196–1302 |
+| **N×M cell grid** with text inside each cell, severity-colored | `render_heatmap_grid` 1381–1491 |
+| **Horizontal strip** of N panels with gap | `create_montage` 116–134 |
+| **Vertical stack of variable-height strips** below the grid (title, primary, heatmap, extra) | both render functions, ~80 lines each, near-identical |
+| **Center text in box** | repeated ~6× as `(box_w.saturating_sub(text_w)) / 2` |
+| **Left-/right-aligned text with inset** | ADD / REMOVE label bar, lines 783–798 and 1170–1185 |
+| **Best-fit char height** to fit longest label in width | `label_char_h = …clamp(GLYPH_H, GLYPH_H*3)` repeated verbatim in both functions |
+| **Word-wrap text within max width** | `render_text_wrapped` |
+| **Fill rect** / **draw rect border** | private helpers, ~50 lines |
+
+`render_montage_impl` and `render_mismatched_montage` are **near-duplicates** — same 2×2 grid math, same label sizing, same text-strip stacking, with a different panel-preparation prologue. That's the strongest internal signal that an abstraction is missing.
+
+## Consumers
+
+- **Internal:** `display.rs` (sixels + PNG save), `examples/visual_diff.rs`.
+- **External, today:** only `zenjpeg` (5 files, all using deprecated `create_comparison_montage_raw`).
+- **Plausible future consumers** in the zen workspace that already produce regression-style or A/B image output: `codec-eval`, `fast-ssim2`, `butteraugli`, `resamplescope-rs`, `zensally` viz, `zenfilters` parity tests, `zenresize` filter visualizations, `zenpipe` integration tests, `zenbench` for image-shaped benchmarks.
+
+So: one real cross-crate consumer today. Several plausible ones — but none that have asked.
+
+## Dependencies the layout code actually needs
+
+- `image::{RgbaImage, imageops::{overlay, resize, crop_imm, FilterType}}`
+- `std::sync::OnceLock` (font cache)
+- the embedded font PNG (`font_strip.png`, ~few KB)
+
+That's it. No `image-tiff`, no archmage, no zensim-specific types. A clean extraction is genuinely lightweight — no dependency graph pain.
+
+## Why a `zengrid` crate would help
+
+1. **Kills the duplicate render functions.** The same-dim and mismatched-dim paths collapse to one `Grid::build(...).into_image()` plus a 30-line panel-prep prologue each. ~300 → ~50 lines per function.
+2. **Reusable shape.** "Labeled image grid + text strips" is what every codec/quality/saliency tool produces; today each one either reinvents it (zenjpeg has its own ad-hoc montages) or reaches into zensim-regress (which drags `zensim` + `seahash` + `fs2` + classification features along).
+3. **Frees zensim-regress to depend on zengrid without dragging weight.** Currently any crate that wants `MontageOptions` has to take the entire regression-testing harness as a dependency.
+4. **Self-contained font is a real product.** `render_text_height` + `render_lines_fitted` over an embedded Consolas strip is genuinely useful and not specific to grids — half the workspace could use it for badge/label rendering. Crates that today reach for `ab_glyph` or `fontdue` (TTF parsing + rasterization) get a much smaller, faster, deterministic alternative for monospace labels.
+5. **Sets up future polish** (legend strips, badges, axis ticks, scrollbar hints) without bloating zensim-regress.
+
+## Why NOT to extract right now
+
+1. **Only one external consumer**, and it uses a *deprecated* API. Three similar usage sites is the usual threshold for an abstraction; we have ~1.
+2. **Premature-generalization risk.** The current API is heavily tuned for "diff montage": dark theme, COLOR_FAIL/OK palette, 2×2 panel layout, automatic spatial heatmap from `SpatialAnalysis`. A first extraction that bakes those defaults in just relocates the problem; one that strips them out has to be rebuilt the moment the second consumer's needs differ.
+3. **The 2×2 layout is mostly straight-line code**, not algorithmic. A clever generic `Cell/Row/Column` builder is not dramatically shorter than the current explicit math — most of the savings come from collapsing the duplicate function, which can be done *inside* zensim-regress with no new crate.
+4. **Cross-crate breakage cost.** zenjpeg is mid-publish-train (per active session marker). Breaking `create_comparison_montage_raw` to route through a new dep is friction we don't need.
+5. **Two crates, not one, if done right.** The font code is independent enough that bundling it under "grid" is awkward — it really wants `zenfont-mono` or similar. Splitting out two crates for one consumer is a lot of plumbing.
+
+## Recommendation
+
+**Phase 1 (do now, no new crate):** refactor *inside* zensim-regress.
+
+- Add `src/layout.rs` with `Cell`, `Grid::build`, `VStack`, centering/alignment helpers, and `fit_char_height_for_label`.
+- Move `fill_rect`, `draw_rect_border`, the 2×2 grid math, the title/primary/heatmap/extra strip stacking into it.
+- Rewrite `render_montage_impl` and `render_mismatched_montage` to share the same `Grid` + `VStack` plumbing. The diff is now only the panel-prep prologue.
+- Keep `font.rs` as-is for now.
+
+This gets you ~80% of the duplication kill at zero blast-radius cost, and **prototypes the API before promoting it to a public crate**.
+
+**Phase 2 (when the second non-zensim consumer asks):** promote `layout.rs` + `font.rs` into a `zengrid` crate.
+
+- Strip diff-specific defaults (palette, heatmap auto-compute) from the public API; pass them in as caller-supplied content.
+- Embedded font becomes either part of `zengrid` or a sibling `zenfont-mono`. My read: keep them in one crate (`zengrid`) until proven wrong — fewer Cargo.toml entries, identical release cadence, no real reason to split.
+- zensim-regress, zenjpeg, codec-eval, fast-ssim2, butteraugli adopt it.
+
+**Sketched Phase 2 API** (for reference, not commitment):
+
+```rust
+// zengrid::layout
+let title  = Strip::title(annotation.title.as_deref(), grid_w);
+let panels = Grid::new(2, 2).pad(8).gap(2)
+    .cell_size(panel_w, label_h + panel_h)
+    .cell(0, 0, Cell::image(expected).top_label("EXPECTED"))
+    .cell(1, 0, Cell::image(actual)  .top_label("ACTUAL"))
+    .cell(0, 1, Cell::image(pdiff)   .top_label("PIXEL DIFF"))
+    .cell(1, 1, Cell::image(sdiff)   .top_label_segments(&[
+        Segment::left("ADD",    [255,180,80,255]),
+        Segment::right("REMOVE",[80,220,220,255]),
+    ]));
+let heatmap = Strip::cells(spatial.cols, spatial.rows, |r, c| { ... });
+let extra   = Strip::wrapped_text(&annotation.extra, COLOR_DETAIL, fit);
+
+VStack::new().bg([18,18,18,255])
+    .push(title).push(panels).push(primary).push(heatmap).push(extra)
+    .render()
+```
+
+```rust
+// zengrid::font
+use zengrid::font::{render_text_height, render_lines_fitted, GLYPH_W, GLYPH_H};
+```
+
+## Bottom line
+
+A `zengrid` crate **is** a good idea — the abstractions are real, the dependencies are clean, the duplication exists. But the cheapest first step is an internal `mod layout` refactor inside zensim-regress that proves the API on the existing two render functions. Promote to a crate **after** the next consumer (most likely codec-eval or zenjpeg's parity tooling) is ready to adopt it; that's the moment when generalizing the palette/heatmap defaults pays for itself instead of just moving them.
+
+Phase 1 is ~1 day of work and immediately useful. Phase 2 is ~1 day of repackaging plus consumer migrations, deferrable until needed.

--- a/zensim-regress/Cargo.toml
+++ b/zensim-regress/Cargo.toml
@@ -16,6 +16,10 @@ default = ["threads"]
 threads = ["zensim/threads"]
 archmage = ["dep:archmage"]
 zenresize = ["dep:zenresize"]
+## INTERNAL — exposes the `layout` module publicly for examples / debug
+## tools. Not part of the public API; the underscore prefix signals
+## "do not depend on this from outside `zensim-regress`."
+_internal_api = []
 
 [dependencies]
 zensim = { workspace = true, default-features = false, features = ["classification"] }
@@ -46,3 +50,9 @@ harness = false
 [[bench]]
 name = "bench_color_diffmap"
 harness = false
+
+# Layout-module gallery — requires the internal-API feature flag because
+# the layout module is private by default.
+[[example]]
+name = "layout_gallery"
+required-features = ["_internal_api"]

--- a/zensim-regress/examples/layout_gallery.rs
+++ b/zensim-regress/examples/layout_gallery.rs
@@ -1,0 +1,895 @@
+//! Self-documenting gallery for the layout module.
+//!
+//! Generates an HTML index page where each "scene" shows its source code
+//! beside its rendered PNG. The macro [`scene!`] captures the body's
+//! source via `stringify!` and runs the same code, so the displayed
+//! source is exactly what produced the image.
+//!
+//! ```text
+//! cargo run -p zensim-regress --example layout_gallery -- /tmp/gallery
+//! # then open /tmp/gallery/index.html
+//! ```
+
+use std::fs;
+use std::path::PathBuf;
+
+use image::{Rgba, RgbaImage};
+use zensim_regress::layout::*;
+
+// ── Helper "templates" used by the template scenes ────────────────────
+
+/// A small status card — title + role + accent color, padded over a
+/// dark background. Hugs content; no `min_width` so a row of these
+/// fits whatever canvas width the caller chose.
+fn status_card(title: &str, role: &str, accent: Color) -> Node {
+    column()
+        .gap(4)
+        .align_items(CrossAlign::Start)
+        .child(line(title, WHITE))
+        .child(line(role, accent))
+        .padding(12)
+        .background(hex("#202531"))
+        .border(hex("#3a3f4d"))
+}
+
+/// Header bar — title left, status right, padded over a colored strip.
+fn header_bar(title: &str, status: &str, status_color: Color) -> Node {
+    layers()
+        .child(fill(hex("#1f2733")))
+        .child(
+            line(title, WHITE)
+                .align(HAlign::Left, VAlign::Center)
+                .padding(12),
+        )
+        .child(
+            line(status, status_color)
+                .align(HAlign::Right, VAlign::Center)
+                .padding(12),
+        )
+        .fill_width()
+        .height(SizeRule::Fixed(40))
+}
+
+/// Solid colored swatch with a centered label — useful for showing
+/// container layout.
+fn swatch(label: &str, color: Color) -> Node {
+    layers()
+        .child(fill(color))
+        .child(line(label, WHITE).center())
+        .into()
+}
+
+/// Colorful gradient square — used as a stand-in for an image.
+fn gradient(w: u32, h: u32) -> RgbaImage {
+    RgbaImage::from_fn(w, h, |x, y| {
+        Rgba([
+            ((x * 255) / w.max(1)) as u8,
+            ((y * 255) / h.max(1)) as u8,
+            (((x + y) * 200) / (w + h).max(1) + 30) as u8,
+            255,
+        ])
+    })
+}
+
+// ── Scene plumbing ────────────────────────────────────────────────────
+
+struct Scene {
+    title: String,
+    description: String,
+    source: String,
+    width: u32,
+    tree: Node,
+    /// Optional scale override — when `Some(s)`, the scene renders via
+    /// `render_with_config` at scale `s` instead of the plain `render`.
+    scale: Option<f32>,
+}
+
+/// Capture the body's source via `stringify!` and build the scene.
+/// `body` must yield something convertible to [`Node`] — a builder, a
+/// modifier chain, a string literal, etc.
+macro_rules! scene {
+    ($title:literal, $desc:literal, $width:expr, $body:expr $(,)?) => {{
+        Scene {
+            title: $title.to_string(),
+            description: $desc.to_string(),
+            source: stringify!($body).to_string(),
+            width: $width,
+            tree: Node::from($body),
+            scale: None,
+        }
+    }};
+}
+
+/// Variant that renders at an explicit scale via `render_with_config`.
+macro_rules! scene_at_scale {
+    ($title:literal, $desc:literal, $width:expr, $scale:expr, $body:expr $(,)?) => {{
+        Scene {
+            title: $title.to_string(),
+            description: $desc.to_string(),
+            source: stringify!($body).to_string(),
+            width: $width,
+            tree: Node::from($body),
+            scale: Some($scale),
+        }
+    }};
+}
+
+fn main() {
+    let dir: PathBuf = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/zenlayout_gallery".to_string())
+        .into();
+    fs::create_dir_all(&dir).expect("create output dir");
+
+    let scenes: Vec<Scene> = vec![
+        // ── Leaves ────────────────────────────────────────────────────
+        scene!(
+            "Solid fill",
+            "`fill(c)` paints `c` over its rect. Wrap in `.size(w, h)` so it has dimensions to paint.",
+            240,
+            fill(hex("#ff6f3c")).size(240, 80)
+        ),
+        scene!(
+            "Plain text",
+            "`line(s, fg)` is a single-line label, sized to fit the constraint width.",
+            400,
+            line("Hello, world!", WHITE).background(hex("#1a1a1a"))
+        ),
+        scene!(
+            "Padded text",
+            "`.padding(n)` wraps a node in [`Node::Padded`]; `.background(c)` paints `c` behind.",
+            300,
+            line("padded", WHITE).padding(20).background(hex("#243949"))
+        ),
+        scene!(
+            "Centered text in oversized box",
+            "`.center()` aligns the child within the rect its parent gives it. Wrap in `.size(w, h)` to give it room.",
+            300,
+            line("centered", WHITE)
+                .center()
+                .size(300, 100)
+                .background(hex("#243949"))
+        ),
+        // ── Row / column basics ───────────────────────────────────────
+        scene!(
+            "Row of swatches",
+            "`row()` is HStack. `gap(n)` separates children. Each `swatch` here is a helper template (see top of file).",
+            600,
+            row()
+                .gap(8)
+                .child(swatch("A", hex("#ef4444")).size(120, 60))
+                .child(swatch("B", hex("#10b981")).size(120, 60))
+                .child(swatch("C", hex("#3b82f6")).size(120, 60))
+                .child(swatch("D", hex("#f59e0b")).size(120, 60))
+                .padding(8)
+                .background(hex("#0e0e10"))
+        ),
+        scene!(
+            "Column with align_items: Center",
+            "Cross-axis alignment applied once on the parent rather than per-child.",
+            300,
+            column()
+                .gap(8)
+                .align_items(CrossAlign::Center)
+                .child(line("title", WHITE))
+                .child(line("subtitle", hex("#888")))
+                .child(swatch("body", hex("#3b82f6")).size(200, 60))
+                .padding(12)
+                .background(hex("#0e0e10"))
+        ),
+        scene!(
+            "justify-content variants",
+            "Same children, different `justify(...)`. Top to bottom: Start, Center, End, SpaceBetween, SpaceAround, SpaceEvenly.",
+            500,
+            column()
+                .gap(8)
+                .child(
+                    row()
+                        .justify(MainAlign::Start)
+                        .child(swatch("a", hex("#ef4444")).size(60, 30))
+                        .child(swatch("b", hex("#10b981")).size(60, 30))
+                        .child(swatch("c", hex("#3b82f6")).size(60, 30))
+                        .fill_width()
+                        .background(hex("#1c1c1c"))
+                )
+                .child(
+                    row()
+                        .justify(MainAlign::Center)
+                        .child(swatch("a", hex("#ef4444")).size(60, 30))
+                        .child(swatch("b", hex("#10b981")).size(60, 30))
+                        .child(swatch("c", hex("#3b82f6")).size(60, 30))
+                        .fill_width()
+                        .background(hex("#1c1c1c"))
+                )
+                .child(
+                    row()
+                        .justify(MainAlign::End)
+                        .child(swatch("a", hex("#ef4444")).size(60, 30))
+                        .child(swatch("b", hex("#10b981")).size(60, 30))
+                        .child(swatch("c", hex("#3b82f6")).size(60, 30))
+                        .fill_width()
+                        .background(hex("#1c1c1c"))
+                )
+                .child(
+                    row()
+                        .justify(MainAlign::SpaceBetween)
+                        .child(swatch("a", hex("#ef4444")).size(60, 30))
+                        .child(swatch("b", hex("#10b981")).size(60, 30))
+                        .child(swatch("c", hex("#3b82f6")).size(60, 30))
+                        .fill_width()
+                        .background(hex("#1c1c1c"))
+                )
+                .child(
+                    row()
+                        .justify(MainAlign::SpaceAround)
+                        .child(swatch("a", hex("#ef4444")).size(60, 30))
+                        .child(swatch("b", hex("#10b981")).size(60, 30))
+                        .child(swatch("c", hex("#3b82f6")).size(60, 30))
+                        .fill_width()
+                        .background(hex("#1c1c1c"))
+                )
+                .child(
+                    row()
+                        .justify(MainAlign::SpaceEvenly)
+                        .child(swatch("a", hex("#ef4444")).size(60, 30))
+                        .child(swatch("b", hex("#10b981")).size(60, 30))
+                        .child(swatch("c", hex("#3b82f6")).size(60, 30))
+                        .fill_width()
+                        .background(hex("#1c1c1c"))
+                )
+                .padding(8)
+                .background(hex("#0e0e10"))
+        ),
+        scene!(
+            "flex-grow weights",
+            "`SizeRule::Grow(n)` (or `.grow(n)`) shares the remainder among Grow children proportionally. Hug children take their natural size first.",
+            500,
+            row()
+                .child(swatch("hug", hex("#ef4444")).size(80, 40))
+                .child(swatch("grow 1", hex("#10b981")).grow(1).fill_height())
+                .child(swatch("grow 2", hex("#3b82f6")).grow(2).fill_height())
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(500, 56)
+        ),
+        // ── Grid ──────────────────────────────────────────────────────
+        scene!(
+            "Uniform Fr grid",
+            "`.cols(n)` is shorthand for n equal-Fr columns. Cells fill the constraint evenly.",
+            400,
+            grid()
+                .cols(3)
+                .equal_rows(2)
+                .gap(4)
+                .cell(0, 0, swatch("0,0", hex("#ef4444")))
+                .cell(1, 0, swatch("1,0", hex("#10b981")))
+                .cell(2, 0, swatch("2,0", hex("#3b82f6")))
+                .cell(0, 1, swatch("0,1", hex("#f59e0b")))
+                .cell(1, 1, swatch("1,1", hex("#a855f7")))
+                .cell(2, 1, swatch("2,1", hex("#ec4899")))
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(400, 200)
+        ),
+        scene!(
+            "Mixed Track sizes (Px / Fr / Auto)",
+            "Like CSS `grid-template-columns: 80px 1fr 2fr`. Px is fixed; Fr splits the remainder weighted; Auto hugs content.",
+            500,
+            grid()
+                .columns([Track::Px(80), Track::Fr(1), Track::Fr(2)])
+                .equal_rows(1)
+                .gap(4)
+                .cell(0, 0, swatch("80px", hex("#ef4444")))
+                .cell(1, 0, swatch("1fr", hex("#10b981")))
+                .cell(2, 0, swatch("2fr", hex("#3b82f6")))
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(500, 60)
+        ),
+        scene!(
+            "ASCII-art areas (`grid-template-areas`)",
+            "Define a layout as text — repeated tokens form a single area whose bounding box is computed. `.place(name, child)` looks up by name.",
+            500,
+            grid()
+                .areas(&[
+                    "header header header",
+                    "side   main   main",
+                    "side   main   main",
+                    "footer footer footer",
+                ])
+                .row_heights([Track::Px(40), Track::Fr(1), Track::Fr(1), Track::Px(30)])
+                .col_widths([Track::Px(100), Track::Fr(1), Track::Fr(1)])
+                .gap(4)
+                .place("header", swatch("HEADER", hex("#3b82f6")))
+                .place("side", swatch("SIDE", hex("#10b981")))
+                .place("main", swatch("MAIN", hex("#f59e0b")))
+                .place("footer", swatch("FOOTER", hex("#a855f7")))
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(500, 280)
+        ),
+        scene!(
+            "Grid with span",
+            "`.span(col, row, colspan, rowspan, child)` extends a cell across multiple tracks.",
+            400,
+            grid()
+                .cols(3)
+                .equal_rows(3)
+                .gap(4)
+                .span(0, 0, 3, 1, swatch("banner (3 cols)", hex("#3b82f6")))
+                .cell(0, 1, swatch("a", hex("#ef4444")))
+                .cell(1, 1, swatch("b", hex("#10b981")))
+                .span(2, 1, 1, 2, swatch("tall (2 rows)", hex("#f59e0b")))
+                .cell(0, 2, swatch("c", hex("#a855f7")))
+                .cell(1, 2, swatch("d", hex("#ec4899")))
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(400, 280)
+        ),
+        // ── Layers / modifiers ────────────────────────────────────────
+        scene!(
+            "Layers (z-stack)",
+            "Children render in painter's order — first child is the bottom of the stack.",
+            300,
+            layers()
+                .child(fill(hex("#1f2937")))
+                .child(swatch("dot", hex("#ef4444")).size(40, 40).center())
+                .child(
+                    line("on top", WHITE)
+                        .align(HAlign::Right, VAlign::Bottom)
+                        .padding(8)
+                )
+                .size(300, 200)
+        ),
+        scene!(
+            "Aspect ratio",
+            "`.aspect_ratio(num, den)` constrains the box to a given ratio.",
+            400,
+            row()
+                .gap(8)
+                .child(
+                    swatch("16:9", hex("#3b82f6"))
+                        .aspect_ratio(16, 9)
+                        .fill_width()
+                )
+                .child(swatch("1:1", hex("#10b981")).aspect_ratio(1, 1))
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(400, 120)
+        ),
+        scene!(
+            "Image fit modes",
+            "`Fit::None` (top-left, no scale), `Fit::Contain` (scale to fit, letterbox), `Fit::Cover` (scale to fill, crop), `Fit::Stretch` (ignore aspect).",
+            520,
+            row()
+                .gap(4)
+                .child(
+                    column().gap(4).child(line("None", WHITE)).child(
+                        image(gradient(60, 40))
+                            .fit(Fit::None)
+                            .size(120, 80)
+                            .background(hex("#1c1c1c"))
+                    )
+                )
+                .child(
+                    column().gap(4).child(line("Contain", WHITE)).child(
+                        image(gradient(60, 40))
+                            .fit(Fit::Contain)
+                            .size(120, 80)
+                            .background(hex("#1c1c1c"))
+                    )
+                )
+                .child(
+                    column().gap(4).child(line("Cover", WHITE)).child(
+                        image(gradient(60, 40))
+                            .fit(Fit::Cover)
+                            .size(120, 80)
+                            .background(hex("#1c1c1c"))
+                    )
+                )
+                .child(
+                    column().gap(4).child(line("Stretch", WHITE)).child(
+                        image(gradient(60, 40))
+                            .fit(Fit::Stretch)
+                            .size(120, 80)
+                            .background(hex("#1c1c1c"))
+                    )
+                )
+                .padding(8)
+                .background(hex("#0e0e10"))
+        ),
+        // ── Labels ────────────────────────────────────────────────────
+        scene!(
+            "Image with default label",
+            "`.label(s)` is the pervasive image-with-label-bar pattern — a `column(label_strip, self)`.",
+            300,
+            image(gradient(200, 120)).label("EXPECTED")
+        ),
+        scene!(
+            "Image with styled label",
+            "`LabelStyle` configures fg/bg/align/padding. `.with_*` builder methods.",
+            300,
+            image(gradient(200, 120)).label_styled(
+                "ACTUAL",
+                &LabelStyle::default()
+                    .with_fg(hex("#ffd166"))
+                    .with_bg(hex("#1f1f3a"))
+                    .with_align(HAlign::Left)
+            )
+        ),
+        scene!(
+            "Image with segmented label (ADD / REMOVE)",
+            "`label_segments` renders multiple aligned segments inside a single strip via Layers.",
+            300,
+            image(gradient(200, 120)).label_segments(
+                vec![
+                    LabelSegment::left("ADD", hex("#ffb454")),
+                    LabelSegment::right("REMOVE", hex("#50e3c2")),
+                ],
+                &LabelStyle::default()
+            )
+        ),
+        // ── Template / data injection ─────────────────────────────────
+        scene!(
+            "Template: status_card called with data",
+            "`status_card(title, role, color)` is defined once at the top of this file. `.grow(1)` on each card makes them share the row width evenly — like CSS `flex: 1`.",
+            560,
+            row()
+                .gap(8)
+                .child(status_card("Alice", "Engineer", hex("#88f")).grow(1))
+                .child(status_card("Bob", "Designer", hex("#f88")).grow(1))
+                .child(status_card("Carol", "PM", hex("#8f8")).grow(1))
+                .child(status_card("Dan", "Researcher", hex("#fc8")).grow(1))
+                .padding(8)
+                .background(hex("#0e0e10"))
+        ),
+        scene!(
+            "Template: header_bar over content",
+            "Same template idea — a `header_bar` helper composed with body content. `.grow(1)` lets the cards share the row width.",
+            500,
+            column()
+                .gap(0)
+                .child(header_bar("zensim-regress", "OK", hex("#10b981")))
+                .child(
+                    row()
+                        .gap(8)
+                        .child(status_card("CI", "passing", hex("#10b981")).grow(1))
+                        .child(status_card("Tests", "276 / 276", hex("#88f")).grow(1))
+                        .child(status_card("Clippy", "clean", hex("#ffd166")).grow(1))
+                        .padding(16)
+                        .background(hex("#0e0e10"))
+                )
+                .background(hex("#0a0a0a"))
+        ),
+        // ── Percent / scale / em ──────────────────────────────────────
+        scene!(
+            "Percent sizing",
+            "`SizeRule::Percent(0.5)` and `Track::Percent(p)` give CSS-`width: 50%`-style relative sizing.",
+            500,
+            row()
+                .gap(4)
+                .child(
+                    swatch("25%", hex("#ef4444"))
+                        .width_percent(0.25)
+                        .fill_height()
+                )
+                .child(
+                    swatch("50%", hex("#10b981"))
+                        .width_percent(0.5)
+                        .fill_height()
+                )
+                .child(swatch("rest", hex("#3b82f6")).grow(1).fill_height())
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(500, 80)
+        ),
+        scene!(
+            "Track::Percent in a grid",
+            "Same idea on grid columns — proportional to total available track-axis space.",
+            500,
+            grid()
+                .columns([Track::Percent(0.2), Track::Percent(0.3), Track::Fr(1)])
+                .equal_rows(1)
+                .gap(4)
+                .cell(0, 0, swatch("20%", hex("#ef4444")))
+                .cell(1, 0, swatch("30%", hex("#10b981")))
+                .cell(2, 0, swatch("rest (Fr)", hex("#3b82f6")))
+                .padding(8)
+                .background(hex("#0e0e10"))
+                .size(500, 60)
+        ),
+        scene_at_scale!(
+            "Same tree, scale = 1.5×",
+            "`render_with_config(..., RenderConfig::new(w).with_scale(1.5))` walks the tree once via `Node::scaled` and multiplies every fixed-pixel quantity (Sized::Fixed, Insets, Px tracks, gap, char_h). Fr / Percent / Grow / Hug are unchanged. `.grow(1)` cards distribute the larger canvas width evenly.",
+            500,
+            1.5,
+            row()
+                .gap(8)
+                .child(status_card("Alice", "Engineer", hex("#88f")).grow(1))
+                .child(status_card("Bob", "Designer", hex("#f88")).grow(1))
+                .child(status_card("Carol", "PM", hex("#8f8")).grow(1))
+                .padding(8)
+                .background(hex("#0e0e10"))
+        ),
+        scene!(
+            "em-relative card",
+            "`em(units)` returns `base_em * units` pixels (default base_em = 16). Used inline at construction time, so spacing scales with the design baseline.",
+            400,
+            column()
+                .gap(em(0.5))
+                .child(line("em-relative", WHITE))
+                .child(line("padding em(1.0)", hex("#888")))
+                .child(swatch("body", hex("#3b82f6")).size(em(15.0), em(3.0)))
+                .padding(em(1.0))
+                .background(hex("#0e0e10"))
+        ),
+        // ── Mini diff montage ─────────────────────────────────────────
+        scene!(
+            "Mini diff montage",
+            "A 2×2 grid of labeled images plus a primary strip and an extra strip — same shape as `compose_montage`. Each cell forces its label to a uniform `label_h` via `.height(SizeRule::Fixed(label_h))` so all 4 headers align horizontally and the row tracks have matching heights.",
+            520,
+            // label_h chosen to fit both auto-fit "EXPECTED"/"ACTUAL"/etc.
+            // (~58 incl. padding) and the multi-segment ADD/REMOVE strip,
+            // matching compose_montage's max-of-strip-heights derivation.
+            // image_h = 160 below.
+            column()
+                .gap(0)
+                .align_items(CrossAlign::Stretch)
+                .child(
+                    grid()
+                        .columns([Track::Px(240), Track::Px(240)])
+                        .rows([Track::Px(58 + 160), Track::Px(58 + 160)])
+                        .gap(8)
+                        .cell(
+                            0,
+                            0,
+                            column()
+                                .gap(0)
+                                .child(
+                                    LabelStyle::default()
+                                        .strip("EXPECTED")
+                                        .height(SizeRule::Fixed(58))
+                                )
+                                .child(image(gradient(240, 160)))
+                        )
+                        .cell(
+                            1,
+                            0,
+                            column()
+                                .gap(0)
+                                .child(
+                                    LabelStyle::default()
+                                        .strip("ACTUAL")
+                                        .height(SizeRule::Fixed(58))
+                                )
+                                .child(image(gradient(240, 160)))
+                        )
+                        .cell(
+                            0,
+                            1,
+                            column()
+                                .gap(0)
+                                .child(
+                                    LabelStyle::default()
+                                        .strip("PIXEL DIFF")
+                                        .height(SizeRule::Fixed(58))
+                                )
+                                .child(image(gradient(240, 160)))
+                        )
+                        .cell(
+                            1,
+                            1,
+                            column()
+                                .gap(0)
+                                .child(
+                                    LabelStyle::default()
+                                        // Multi-segment strips fall back to a
+                                        // conservative default char_h so the
+                                        // L/R groups don't overflow the strip
+                                        // even at narrow widths. Override
+                                        // explicitly only when you've sized
+                                        // your strip to fit.
+                                        .segmented_strip(vec![
+                                            LabelSegment::left("ADD", hex("#ffb454")),
+                                            LabelSegment::right("REMOVE", hex("#50e3c2")),
+                                        ])
+                                        .height(SizeRule::Fixed(58))
+                                )
+                                .child(image(gradient(240, 160)))
+                        )
+                        .padding(8)
+                )
+                .child(
+                    line("FAIL — zdsim 0.18 > 0.01", hex("#ff5050"))
+                        .center()
+                        .padding(8)
+                        .fill_width()
+                        .background(hex("#1e1e1e"))
+                )
+                .child(
+                    line(
+                        "alpha: max delta 0  •  pixels_differing 34.2%",
+                        hex("#aaaaaa")
+                    )
+                    .padding(8)
+                    .fill_width()
+                    .background(hex("#191919"))
+                )
+                .background(hex("#121212"))
+        ),
+    ];
+
+    // ── Render & save ─────────────────────────────────────────────────
+    let mut html_scenes = String::new();
+    let mut toc = String::new();
+    for (i, sc) in scenes.iter().enumerate() {
+        let canvas = match sc.scale {
+            None => render(&sc.tree, sc.width),
+            Some(scale) => {
+                render_with_config(&sc.tree, &RenderConfig::new(sc.width).with_scale(scale))
+            }
+        };
+        let img_path = dir.join(format!("scene_{:02}.png", i + 1));
+        canvas.save(&img_path).expect("save png");
+        let img_name = img_path.file_name().unwrap().to_string_lossy().into_owned();
+        let anchor = format!("scene-{:02}", i + 1);
+        toc.push_str(&format!(
+            "  <a href=\"#{anchor}\">{:02}. {}</a>\n",
+            i + 1,
+            html_escape(&sc.title)
+        ));
+        html_scenes.push_str(&render_scene_html(
+            i + 1,
+            &anchor,
+            sc,
+            &img_name,
+            canvas.width(),
+            canvas.height(),
+        ));
+    }
+
+    let html = format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>zensim-regress layout gallery</title>
+<style>{css}</style>
+</head>
+<body>
+<header>
+  <h1>zensim-regress layout gallery</h1>
+  <p>Each scene below shows the source code that produced the rendered PNG beside it.
+     Generated by <code>cargo run -p zensim-regress --example layout_gallery</code>.</p>
+  <nav class="toc">
+{toc}  </nav>
+</header>
+<main>
+{html_scenes}</main>
+<footer>
+  <p>{n} scenes — rendered with <code>zensim_regress::layout</code>.</p>
+</footer>
+</body>
+</html>
+"#,
+        css = CSS,
+        n = scenes.len()
+    );
+
+    let html_path = dir.join("index.html");
+    fs::write(&html_path, html).expect("write index.html");
+
+    println!("Wrote {} scenes to {}", scenes.len(), dir.display());
+    println!("Open: file://{}", html_path.display());
+}
+
+fn render_scene_html(
+    n: usize,
+    anchor: &str,
+    sc: &Scene,
+    img_name: &str,
+    img_w: u32,
+    img_h: u32,
+) -> String {
+    let pretty = pretty_source(&sc.source);
+    format!(
+        r#"<section class="scene" id="{anchor}">
+  <h2>{n:02}. {title}</h2>
+  <p class="desc">{desc}</p>
+  <div class="scene-grid">
+    <pre><code>{code}</code></pre>
+    <div class="scene-image">
+      <img src="{img_name}" alt="{title}">
+      <div class="scene-image-meta">{img_w}×{img_h} • constraint width = {cw}</div>
+    </div>
+  </div>
+</section>
+"#,
+        title = html_escape(&sc.title),
+        desc = html_escape(&sc.description),
+        code = html_escape(&pretty),
+        cw = sc.width,
+    )
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// `stringify!` runs the tokens through `proc_macro::TokenStream`'s
+/// formatter, which spaces tokens out but does not insert line breaks.
+/// Add line breaks after `;` and after method-call dots when the line
+/// is long, plus indentation for `{` / `}` and `[` / `]` blocks.
+fn pretty_source(s: &str) -> String {
+    let mut out = String::new();
+    let mut indent: i32 = 0;
+    let mut chars = s.chars().peekable();
+    let mut in_string = false;
+    let mut last_char = ' ';
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            out.push(ch);
+            if ch == '"' && last_char != '\\' {
+                in_string = false;
+            }
+            last_char = ch;
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                out.push(ch);
+                in_string = true;
+            }
+            '{' | '[' => {
+                out.push(ch);
+                indent += 1;
+                push_newline(&mut out, indent);
+            }
+            '}' | ']' => {
+                indent -= 1;
+                trim_trailing_ws(&mut out);
+                push_newline(&mut out, indent);
+                out.push(ch);
+            }
+            ',' => {
+                out.push(ch);
+                push_newline(&mut out, indent);
+                // Skip space directly after a comma (we just added a newline).
+                while let Some(&next) = chars.peek() {
+                    if next == ' ' {
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            '.' if last_char.is_alphanumeric() || last_char == ')' || last_char == ']' => {
+                // Method-chain call. Break before . when line is already long.
+                let line_len = out.lines().last().map_or(0, |l| l.len());
+                if line_len > 50 {
+                    push_newline(&mut out, indent + 1);
+                    out.push(ch);
+                } else {
+                    out.push(ch);
+                }
+            }
+            _ => out.push(ch),
+        }
+        last_char = ch;
+    }
+    out.trim().to_string()
+}
+
+fn push_newline(out: &mut String, indent: i32) {
+    out.push('\n');
+    for _ in 0..indent.max(0) {
+        out.push_str("    ");
+    }
+}
+
+fn trim_trailing_ws(out: &mut String) {
+    while let Some(c) = out.chars().last() {
+        if c == ' ' || c == '\n' {
+            out.pop();
+        } else {
+            break;
+        }
+    }
+}
+
+const CSS: &str = r#"
+:root {
+    --bg: #0a0a0a;
+    --panel: #161616;
+    --code-bg: #1c1c1c;
+    --fg: #e4e4e7;
+    --muted: #71717a;
+    --accent: #88c0ff;
+    --border: #27272a;
+}
+* { box-sizing: border-box; }
+body {
+    margin: 0;
+    padding: 32px;
+    background: var(--bg);
+    color: var(--fg);
+    font: 15px/1.5 -apple-system, "Segoe UI", "Helvetica Neue", system-ui, sans-serif;
+}
+header { max-width: 1100px; margin: 0 auto 32px; }
+main { max-width: 1100px; margin: 0 auto; }
+footer { max-width: 1100px; margin: 32px auto 0; color: var(--muted); }
+h1 { color: var(--accent); margin: 0 0 8px; font-weight: 600; font-size: 28px; }
+h2 { color: var(--accent); margin: 0 0 4px; font-size: 18px; font-weight: 600; }
+p { margin: 4px 0 0; }
+code { font-family: "SF Mono", Menlo, Consolas, ui-monospace, monospace; font-size: 13px; }
+.toc {
+    margin-top: 16px;
+    padding: 12px 16px;
+    background: var(--panel);
+    border-left: 3px solid var(--accent);
+    border-radius: 4px;
+    columns: 2;
+    column-gap: 24px;
+}
+.toc a {
+    display: block;
+    color: var(--fg);
+    text-decoration: none;
+    padding: 2px 0;
+    font-size: 13px;
+}
+.toc a:hover { color: var(--accent); }
+.scene {
+    margin: 24px 0;
+    padding: 20px 24px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+}
+.desc { color: var(--muted); margin-top: 4px; max-width: 70ch; }
+.scene-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-top: 16px;
+    align-items: start;
+}
+@media (max-width: 900px) { .scene-grid { grid-template-columns: 1fr; } }
+.scene-grid pre {
+    margin: 0;
+    padding: 14px 16px;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    overflow: auto;
+    max-height: 600px;
+    font: 12.5px/1.5 "SF Mono", Menlo, Consolas, ui-monospace, monospace;
+    color: #d4d4d4;
+    white-space: pre;
+    tab-size: 4;
+}
+.scene-image {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.scene-image img {
+    max-width: 100%;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: #000;
+    image-rendering: pixelated;
+}
+.scene-image-meta {
+    margin-top: 8px;
+    color: var(--muted);
+    font-size: 12px;
+    font-family: "SF Mono", Menlo, Consolas, ui-monospace, monospace;
+}
+"#;

--- a/zensim-regress/examples/montage_diff.rs
+++ b/zensim-regress/examples/montage_diff.rs
@@ -1,0 +1,105 @@
+//! Compare two directories of montage PNGs (baseline vs new) and report
+//! per-pixel differences. Usage:
+//!   cargo run -p zensim-regress --example montage_diff -- <baseline_dir> <new_dir>
+
+use std::env;
+
+use image::{ImageReader, Rgba, RgbaImage};
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let baseline_dir = args
+        .next()
+        .unwrap_or_else(|| "/tmp/montage_baseline".into());
+    let new_dir = args.next().unwrap_or_else(|| "/tmp/montage_new".into());
+
+    let scenes = [
+        "01_samedim_plain",
+        "02_samedim_annotated",
+        "03_mismatched_plain",
+        "04_mismatched_annotated",
+        "05_tiny_pixelate",
+        "06_custom_labels",
+    ];
+
+    println!(
+        "{:<30} {:>10} {:>10} {:>8} {:>8} {:>10}",
+        "scene", "dim_b", "dim_n", "px_diff%", "max_d", "avg_d"
+    );
+    println!("{}", "-".repeat(80));
+
+    let mut all_clean = true;
+    for s in &scenes {
+        let a_path = format!("{}/{}.png", baseline_dir, s);
+        let b_path = format!("{}/{}.png", new_dir, s);
+        let a = match ImageReader::open(&a_path).map(|r| r.decode().unwrap().to_rgba8()) {
+            Ok(img) => img,
+            Err(e) => {
+                println!("{:<30} ERROR: {}", s, e);
+                continue;
+            }
+        };
+        let b = match ImageReader::open(&b_path).map(|r| r.decode().unwrap().to_rgba8()) {
+            Ok(img) => img,
+            Err(e) => {
+                println!("{:<30} ERROR: {}", s, e);
+                continue;
+            }
+        };
+        let dim_a = format!("{}x{}", a.width(), a.height());
+        let dim_b = format!("{}x{}", b.width(), b.height());
+        if a.dimensions() != b.dimensions() {
+            println!("{:<30} {:>10} {:>10}  DIM-MISMATCH", s, dim_a, dim_b);
+            all_clean = false;
+            continue;
+        }
+
+        let mut max_d = 0u32;
+        let mut sum_d = 0u64;
+        let mut diff_pixels = 0u64;
+        for (pa, pb) in a.pixels().zip(b.pixels()) {
+            let d = (0..4)
+                .map(|i| (pa.0[i] as i32 - pb.0[i] as i32).unsigned_abs())
+                .max()
+                .unwrap();
+            if d > 0 {
+                diff_pixels += 1;
+            }
+            max_d = max_d.max(d);
+            sum_d += d as u64;
+        }
+        let total_px = (a.width() * a.height()) as u64;
+        let pct = 100.0 * diff_pixels as f64 / total_px as f64;
+        let avg = sum_d as f64 / (total_px * 4) as f64;
+        let marker = if max_d == 0 {
+            "✓"
+        } else if pct < 1.0 {
+            "≈"
+        } else {
+            "✗"
+        };
+
+        println!(
+            "{:<30} {:>10} {:>10} {:>7.2}% {:>8} {:>10.4} {}",
+            s, dim_a, dim_b, pct, max_d, avg, marker
+        );
+        if max_d > 0 {
+            all_clean = false;
+            // Save a binary diff visualization: white where different.
+            let mut diff_img = RgbaImage::new(a.width(), a.height());
+            for (x, y, pa) in a.enumerate_pixels() {
+                let pb = b.get_pixel(x, y);
+                let d = (0..4)
+                    .map(|i| (pa.0[i] as i32 - pb.0[i] as i32).unsigned_abs())
+                    .max()
+                    .unwrap();
+                let v = (d * 255 / 234).min(255) as u8;
+                diff_img.put_pixel(x, y, Rgba([v, 0, 0, 255]));
+            }
+            let _ = diff_img.save(format!("/tmp/montage_diff_{}.png", s));
+        }
+    }
+
+    println!();
+    println!("Clean: {}", all_clean);
+}

--- a/zensim-regress/examples/montage_regression.rs
+++ b/zensim-regress/examples/montage_regression.rs
@@ -1,0 +1,124 @@
+//! Regression-comparison harness for the montage compositor.
+//!
+//! Renders six representative montages — same-dim plain, same-dim
+//! annotated, mismatched-dim plain, mismatched-dim annotated, tiny
+//! image (pixelate-upscale), and custom labels — into the directory
+//! given by the first arg. Used to confirm the layout-module port
+//! preserves visual output.
+//!
+//! ```text
+//! cargo run -p zensim-regress --example montage_regression -- /tmp/baseline
+//! ```
+
+use std::env;
+use std::path::PathBuf;
+
+use image::{Rgba, RgbaImage};
+use zensim_regress::diff_image::{AnnotationText, MontageOptions};
+
+fn main() {
+    let dir: PathBuf = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "/tmp/montage_regression".to_string())
+        .into();
+    std::fs::create_dir_all(&dir).expect("create output dir");
+
+    // Scene 1: same-dim, no annotations
+    {
+        let exp = gradient(96, 96);
+        let act = with_center_shift(&exp, 30, -20);
+        let m = MontageOptions::default().render(&exp, &act, &AnnotationText::empty());
+        m.save(dir.join("01_samedim_plain.png")).unwrap();
+    }
+
+    // Scene 2: same-dim with full annotation + heatmap
+    {
+        let exp = gradient(96, 96);
+        let act = with_center_shift(&exp, 60, -40);
+        let mut ann = AnnotationText::empty().with_title("scene 2 — annotated with heatmap");
+        ann.primary_lines = vec![
+            ("FAIL".to_string(), [255, 80, 80, 255]),
+            ("zdsim 0.18 > 0.01 FAIL".to_string(), [255, 80, 80, 255]),
+            (
+                "max_delta [0,60,40,0] > 4 FAIL".to_string(),
+                [255, 80, 80, 255],
+            ),
+        ];
+        ann.extra = "alpha: max delta 0  •  pixels_differing 34.2%".to_string();
+        let m = MontageOptions::default().render(&exp, &act, &ann);
+        m.save(dir.join("02_samedim_annotated.png")).unwrap();
+    }
+
+    // Scene 3: mismatched dimensions
+    {
+        let exp = gradient(96, 64);
+        let act = gradient(72, 96);
+        let m = MontageOptions::default().render(&exp, &act, &AnnotationText::empty());
+        m.save(dir.join("03_mismatched_plain.png")).unwrap();
+    }
+
+    // Scene 4: mismatched dims with annotation
+    {
+        let exp = gradient(96, 64);
+        let act = gradient(72, 96);
+        let mut ann = AnnotationText::empty().with_title("scene 4 — mismatched dims annotated");
+        ann.primary_lines = vec![(
+            "DIMENSION MISMATCH 96x64 vs 72x96".to_string(),
+            [255, 80, 80, 255],
+        )];
+        ann.extra = "compared on shared 96x96 canvas".to_string();
+        let m = MontageOptions::default().render(&exp, &act, &ann);
+        m.save(dir.join("04_mismatched_annotated.png")).unwrap();
+    }
+
+    // Scene 5: tiny image (triggers pixelate-upscale)
+    {
+        let exp = gradient(16, 16);
+        let act = with_center_shift(&exp, 80, -50);
+        let m = MontageOptions::default().render(&exp, &act, &AnnotationText::empty());
+        m.save(dir.join("05_tiny_pixelate.png")).unwrap();
+    }
+
+    // Scene 6: custom labels + heatmap disabled
+    {
+        let exp = gradient(96, 96);
+        let act = with_center_shift(&exp, 40, -30);
+        let mut opts = MontageOptions::default();
+        opts.expected_label = Some("REFERENCE-LONG-NAME".to_string());
+        opts.actual_label = Some("CANDIDATE".to_string());
+        opts.show_spatial_heatmap = false;
+        let m = opts.render(&exp, &act, &AnnotationText::empty());
+        m.save(dir.join("06_custom_labels.png")).unwrap();
+    }
+
+    println!("Wrote 6 scenes to {}", dir.display());
+}
+
+fn gradient(w: u32, h: u32) -> RgbaImage {
+    RgbaImage::from_fn(w, h, |x, y| {
+        Rgba([
+            ((x * 255) / w.max(1)) as u8,
+            ((y * 255) / h.max(1)) as u8,
+            (((x + y) * 255) / (w + h).max(1)) as u8,
+            255,
+        ])
+    })
+}
+
+fn with_center_shift(src: &RgbaImage, dg: i16, db: i16) -> RgbaImage {
+    let (w, h) = (src.width(), src.height());
+    RgbaImage::from_fn(w, h, |x, y| {
+        let p = src.get_pixel(x, y);
+        let in_center = x > w / 4 && x < 3 * w / 4 && y > h / 4 && y < 3 * h / 4;
+        if in_center {
+            Rgba([
+                p[0],
+                p[1].saturating_add_signed(dg.try_into().unwrap_or(0)),
+                p[2].saturating_add_signed(db.try_into().unwrap_or(0)),
+                255,
+            ])
+        } else {
+            *p
+        }
+    })
+}

--- a/zensim-regress/src/diff_image.rs
+++ b/zensim-regress/src/diff_image.rs
@@ -706,8 +706,6 @@ fn render_montage_impl(
     actual: &RgbaImage,
     annotation: &AnnotationText,
 ) -> RgbaImage {
-    use crate::font;
-
     let amplification = options.amplification;
 
     // Generate diffs at original resolution (before upscale) so pixel-level
@@ -723,272 +721,208 @@ fn render_montage_impl(
 
     // Pixelate-upscale all four panels if the source is tiny.
     let min_panel_size = options.min_panel_size;
-    let up_expected;
-    let up_actual;
-    let up_pixel_diff;
-    let up_struct_diff;
-    let (expected, actual, pixel_diff, struct_diff) =
-        if min_panel_size > 0 && (w < min_panel_size || h < min_panel_size) {
-            up_expected = pixelate_upscale(expected, min_panel_size);
-            up_actual = pixelate_upscale(actual, min_panel_size);
-            up_pixel_diff = pixelate_upscale(&pixel_diff, min_panel_size);
-            up_struct_diff = pixelate_upscale(&struct_diff, min_panel_size);
-            (&up_expected, &up_actual, &up_pixel_diff, &up_struct_diff)
-        } else {
-            (expected, actual, &pixel_diff, &struct_diff)
-        };
+    let panels = if min_panel_size > 0 && (w < min_panel_size || h < min_panel_size) {
+        [
+            pixelate_upscale(expected, min_panel_size),
+            pixelate_upscale(actual, min_panel_size),
+            pixelate_upscale(&pixel_diff, min_panel_size),
+            pixelate_upscale(&struct_diff, min_panel_size),
+        ]
+    } else {
+        [expected.clone(), actual.clone(), pixel_diff, struct_diff]
+    };
 
-    // Minimum padding: 30% of a base char width, at least 8px
+    compose_montage(panels, options, annotation, &spatial, has_differences, 10)
+}
+
+/// Shared 2×2 grid + annotation strip composition for both same-dim and
+/// mismatched-dim montages. Takes the four prepared panel images and
+/// produces the final output via the [`crate::layout`] module.
+///
+/// `longest_label_floor` sets a lower bound on the "longest label" used
+/// to derive the ADD/REMOVE char height — same-dim uses 10 (the length
+/// of "PIXEL DIFF"), mismatched uses 20 to reserve space for resized
+/// annotations on tighter cells.
+fn compose_montage(
+    panels: [RgbaImage; 4],
+    options: &MontageOptions,
+    annotation: &AnnotationText,
+    spatial: &SpatialAnalysis,
+    has_differences: bool,
+    longest_label_floor: u32,
+) -> RgbaImage {
+    use crate::font;
+    use crate::layout::{
+        self, CrossAlign, HAlign, Insets, LabelSegment, LabelStyle, LayoutMod, SizeRule, Track,
+        VAlign, rgb,
+    };
+
+    let [p_exp, p_act, p_pdiff, p_sdiff] = panels;
+
     let min_pad = (font::GLYPH_W * 3 / 10).max(8);
     let pad = options.gap.max(min_pad);
-    let bg = Rgba([18, 18, 18, 255]);
-    let label_fg = [220, 220, 220, 255];
-    let label_bg = [40, 40, 40, 255];
+    let canvas_bg = rgb(18, 18, 18);
+    let label_fg = rgb(220, 220, 220);
+    let label_bg = rgb(40, 40, 40);
+    let title_bg = rgb(25, 25, 25);
+    let primary_bg = rgb(30, 30, 30);
+    let extra_bg = rgb(25, 25, 25);
+    let separator = rgb(60, 60, 60);
 
-    let panel_images: [&RgbaImage; 4] = [expected, actual, pixel_diff, struct_diff];
+    let panel_w = p_exp.width();
+    let panel_h = p_exp.height();
+    let cell_w = panel_w;
+    let grid_w = pad + cell_w + pad + cell_w + pad;
+    let label_area_w = panel_w.saturating_sub(pad * 2);
+    let text_avail = grid_w.saturating_sub(pad * 2);
 
-    let panel_w = expected.width();
-    let panel_h = expected.height();
-
-    // Label sizing: fit the longest of ("PIXEL DIFF" + caller-supplied
-    // labels) within cell_w minus padding. When callers override, the
-    // column widths auto-shrink so long labels still fit.
-    let label_inset = pad;
-    let label_area_w = panel_w.saturating_sub(label_inset * 2);
     let expected_text: &str = options.expected_label.as_deref().unwrap_or("EXPECTED");
     let actual_text: &str = options.actual_label.as_deref().unwrap_or("ACTUAL");
+
+    // Char height for ADD/REMOVE — clamped to [GLYPH_H, GLYPH_H*3].
+    // Plain labels remain auto-fit per their own length.
     let longest_label = expected_text
         .len()
         .max(actual_text.len())
-        .max("PIXEL DIFF".len()) as u32;
-    let label_char_h = ((label_area_w as f32 / longest_label as f32)
+        .max(longest_label_floor as usize) as u32;
+    let ar_char_h = ((label_area_w as f32 / longest_label as f32)
         * (font::GLYPH_H as f32 / font::GLYPH_W as f32))
         .floor() as u32;
-    let label_char_h = label_char_h.clamp(font::GLYPH_H, font::GLYPH_H * 3);
+    let ar_char_h = ar_char_h.clamp(font::GLYPH_H, font::GLYPH_H * 3);
 
-    // Plain labels: rendered centered within panel_w via render_lines_fitted
-    let plain_labels: [&str; 3] = [expected_text, actual_text, "PIXEL DIFF"];
-    let plain_images: Vec<(Vec<u8>, u32, u32)> = plain_labels
-        .iter()
-        .map(|label| {
-            let lines: Vec<(&str, [u8; 4])> = vec![(*label, label_fg)];
-            font::render_lines_fitted(&lines, label_bg, label_area_w)
-        })
-        .collect();
+    // Unified label strip height = max of all four rendered labels + 4.
+    let plain_h = |s: &str| font::measure_lines_fitted(&[(s, label_fg)], label_area_w).1;
+    let label_h = plain_h(expected_text)
+        .max(plain_h(actual_text))
+        .max(plain_h("PIXEL DIFF"))
+        .max(ar_char_h)
+        + 4;
 
-    // ADD  REMOVE: left-aligned and right-aligned within the cell
-    let add_img = font::render_text_height("ADD", [255, 180, 80, 255], label_bg, label_char_h);
-    let rem_img = font::render_text_height("REMOVE", [80, 220, 220, 255], label_bg, label_char_h);
-    let ar_h = label_char_h;
-    let mut ar_rgba = RgbaImage::from_pixel(panel_w, ar_h, Rgba(label_bg));
-    // ADD left-aligned with inset
-    if add_img.1 > 0
-        && add_img.2 > 0
-        && let Some(img) = RgbaImage::from_raw(add_img.1, add_img.2, add_img.0.clone())
-    {
-        imageops::overlay(&mut ar_rgba, &img, label_inset as i64, 0);
-    }
-    // REMOVE right-aligned with inset
-    if rem_img.1 > 0
-        && rem_img.2 > 0
-        && let Some(img) = RgbaImage::from_raw(rem_img.1, rem_img.2, rem_img.0.clone())
-    {
-        let rx = panel_w.saturating_sub(rem_img.1 + label_inset);
-        imageops::overlay(&mut ar_rgba, &img, rx as i64, 0);
-    }
-    let ar_raw = ar_rgba.into_raw();
+    let plain_style = LabelStyle::default()
+        .with_fg(label_fg)
+        .with_bg(label_bg)
+        .with_align(HAlign::Center)
+        .with_padding(Insets::xy(pad, 0));
+    let segmented_style = LabelStyle::default()
+        .with_fg(label_fg)
+        .with_bg(label_bg)
+        .with_padding(Insets::xy(pad, 0))
+        .with_char_h(ar_char_h);
 
-    let label_images: Vec<(Vec<u8>, u32, u32)> = vec![
-        plain_images[0].clone(),
-        plain_images[1].clone(),
-        plain_images[2].clone(),
-        (ar_raw, panel_w, ar_h),
-    ];
+    let cell = |panel: RgbaImage, label_node: layout::Node| -> layout::Node {
+        layout::column()
+            .child(label_node.height(SizeRule::Fixed(label_h)))
+            .child(layout::image(panel))
+            .into()
+    };
 
-    let label_h = label_images.iter().map(|(_, _, h)| *h).max().unwrap_or(0) + 4;
+    let panels_grid = layout::grid()
+        .columns([Track::Px(cell_w), Track::Px(cell_w)])
+        .row_heights([Track::Px(label_h + panel_h), Track::Px(label_h + panel_h)])
+        .gap(pad)
+        .padding(pad)
+        .cell(0, 0, cell(p_exp, plain_style.strip(expected_text)))
+        .cell(1, 0, cell(p_act, plain_style.strip(actual_text)))
+        .cell(0, 1, cell(p_pdiff, plain_style.strip("PIXEL DIFF")))
+        .cell(
+            1,
+            1,
+            cell(
+                p_sdiff,
+                segmented_style.segmented_strip(vec![
+                    LabelSegment::left("ADD", rgb(255, 180, 80)),
+                    LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+                ]),
+            ),
+        );
 
-    // 2x2 grid dimensions
-    let cell_w = panel_w;
-    let cell_h = label_h + panel_h;
-    let grid_w = pad + cell_w + pad + cell_w + pad;
-    let grid_h = pad + cell_h + pad + cell_h + pad;
+    let mut col = layout::column()
+        .align_items(CrossAlign::Stretch)
+        .child(panels_grid);
 
-    // Title text — white, fitted to grid width
-    let text_avail = grid_w.saturating_sub(pad * 2);
-    let title_rendered = annotation.title.as_ref().and_then(|t| {
-        if t.is_empty() {
+    // Pre-rasterize annotation text into Image leaves so the layout module
+    // doesn't re-compute char_h via the auto-fit formula at paint time
+    // (which would shift one or two pixels when an enclosing Align reduces
+    // the rect to the measured natural width).
+    fn rasterized_image(buf: Vec<u8>, w: u32, h: u32) -> Option<RgbaImage> {
+        if w == 0 || h == 0 {
             return None;
         }
-        let lines: Vec<(&str, [u8; 4])> = vec![(t.as_str(), [255, 255, 255, 255])];
-        Some(font::render_lines_fitted(
-            &lines,
-            [25, 25, 25, 255],
-            text_avail,
-        ))
-    });
+        RgbaImage::from_raw(w, h, buf)
+    }
 
-    // Primary text — colored per-line, fitted to grid width (no wrapping)
-    let primary_rendered = if !annotation.primary_lines.is_empty() {
+    if let Some(t) = annotation.title.as_deref().filter(|s| !s.is_empty()) {
+        let lines: Vec<(&str, [u8; 4])> = vec![(t, [255, 255, 255, 255])];
+        let (tbuf, tw, th) = font::render_lines_fitted(&lines, title_bg, text_avail);
+        if let Some(title_img) = rasterized_image(tbuf, tw, th) {
+            let title_strip = layout::layers()
+                .child(layout::fill(title_bg))
+                .child(layout::image(title_img).center().padding(pad))
+                .child(
+                    layout::empty()
+                        .background(separator)
+                        .height(SizeRule::Fixed(1))
+                        .fill_width()
+                        .padding_xy(pad, 0)
+                        .align_v(VAlign::Bottom),
+                )
+                .fill_width();
+            col = col.child(title_strip);
+        }
+    }
+
+    if !annotation.primary_lines.is_empty() {
         let line_refs: Vec<(&str, [u8; 4])> = annotation
             .primary_lines
             .iter()
             .map(|(s, c)| (s.as_str(), *c))
             .collect();
-        let r = font::render_lines_fitted(&line_refs, [30, 30, 30, 255], text_avail);
-        Some(r)
-    } else {
-        None
-    };
+        let (pbuf, pw, ph) = font::render_lines_fitted(&line_refs, primary_bg, text_avail);
+        if let Some(primary_img) = rasterized_image(pbuf, pw, ph) {
+            let primary_strip = layout::image(primary_img)
+                .center()
+                .padding(pad)
+                .background(primary_bg)
+                .fill_width();
+            col = col.child(primary_strip);
+        }
+    }
 
-    // Heatmap grid — only shown when there are actual differences AND
-    // the caller hasn't opted out via `show_spatial_heatmap = false`.
-    let heatmap = if has_differences && options.show_spatial_heatmap {
-        Some(render_heatmap_grid(&spatial, grid_w, pad))
-    } else {
-        None
-    };
+    if has_differences && options.show_spatial_heatmap {
+        let heatmap_img = render_heatmap_grid(spatial, grid_w, pad);
+        col = col.child(layout::image(heatmap_img));
+    }
 
-    // Extra text (alpha info etc) — small, word-wrapped
-    let primary_line_h = primary_rendered
-        .as_ref()
-        .map_or(font::GLYPH_H, |(_, _, h)| {
-            let n = annotation.primary_lines.len().max(1) as u32;
-            *h / n
-        });
-    let extra_char_h = (primary_line_h * 7 / 10).max(font::GLYPH_H / 4);
-    let extra_rendered = if !annotation.extra.is_empty() {
-        let r = font::render_text_wrapped(
+    if !annotation.extra.is_empty() {
+        let primary_line_h = if !annotation.primary_lines.is_empty() {
+            let refs: Vec<(&str, [u8; 4])> = annotation
+                .primary_lines
+                .iter()
+                .map(|(s, c)| (s.as_str(), *c))
+                .collect();
+            let total = font::measure_lines_fitted(&refs, text_avail).1;
+            total / annotation.primary_lines.len().max(1) as u32
+        } else {
+            font::GLYPH_H
+        };
+        let extra_char_h = (primary_line_h * 7 / 10).max(font::GLYPH_H / 4);
+        let (ebuf, ew, eh) = font::render_text_wrapped(
             &annotation.extra,
             COLOR_DETAIL,
-            [25, 25, 25, 255],
+            extra_bg,
             extra_char_h,
             text_avail,
         );
-        Some(r)
-    } else {
-        None
-    };
-
-    let title_h = title_rendered.as_ref().map_or(0, |(_, _, h)| *h + pad * 2);
-    let primary_h = primary_rendered
-        .as_ref()
-        .map_or(0, |(_, _, h)| *h + pad * 2);
-    let heatmap_h = heatmap.as_ref().map_or(0, |img| img.height());
-    let extra_h = extra_rendered.as_ref().map_or(0, |(_, _, h)| *h + pad * 2);
-
-    let total_w = grid_w;
-    let total_h = grid_h + title_h + primary_h + heatmap_h + extra_h;
-
-    let mut output = RgbaImage::from_pixel(total_w, total_h, bg);
-
-    // Place 4 panels in 2x2 grid — clip panels to cell bounds
-    for (i, panel) in panel_images.iter().enumerate() {
-        let col = (i % 2) as u32;
-        let row = (i / 2) as u32;
-        let x0 = pad + col * (cell_w + pad);
-        let y0 = pad + row * (cell_h + pad);
-
-        // Label bar background
-        fill_rect(&mut output, x0, y0, cell_w, label_h, label_bg);
-
-        // Label text centered in bar
-        let (ref lbuf, lw, lh) = label_images[i];
-        if lw > 0 && lh > 0 {
-            let lx_off = (cell_w.saturating_sub(lw)) / 2;
-            let ly_off = (label_h.saturating_sub(lh)) / 2;
-            if let Some(label_img) = RgbaImage::from_raw(lw, lh, lbuf.clone()) {
-                imageops::overlay(
-                    &mut output,
-                    &label_img,
-                    (x0 + lx_off) as i64,
-                    (y0 + ly_off) as i64,
-                );
-            }
-        }
-
-        // Panel image — crop to cell_w × panel_h if it overflows
-        let pw = panel.width().min(cell_w);
-        let ph = panel.height().min(panel_h);
-        let cropped = imageops::crop_imm(*panel, 0, 0, pw, ph).to_image();
-        imageops::overlay(&mut output, &cropped, x0 as i64, (y0 + label_h) as i64);
-    }
-
-    // Title strip
-    let mut y_cursor = grid_h;
-    if let Some((tbuf, tw, th)) = title_rendered
-        && tw > 0
-        && th > 0
-    {
-        fill_rect(
-            &mut output,
-            0,
-            y_cursor,
-            total_w,
-            title_h,
-            [25, 25, 25, 255],
-        );
-        if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-            let tx = (total_w.saturating_sub(tw)) / 2;
-            imageops::overlay(&mut output, &text_img, tx as i64, (y_cursor + pad) as i64);
-        }
-        y_cursor += title_h;
-        // Horizontal separator line
-        fill_rect(
-            &mut output,
-            pad,
-            y_cursor.saturating_sub(1),
-            total_w - pad * 2,
-            1,
-            [60, 60, 60, 255],
-        );
-    }
-
-    // Primary text strip — center the first line (PASS/FAIL)
-    if let Some((tbuf, tw, th)) = primary_rendered
-        && tw > 0
-        && th > 0
-    {
-        fill_rect(
-            &mut output,
-            0,
-            y_cursor,
-            total_w,
-            primary_h,
-            [30, 30, 30, 255],
-        );
-        if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-            // Center horizontally
-            let tx = (total_w.saturating_sub(tw)) / 2;
-            imageops::overlay(&mut output, &text_img, tx as i64, (y_cursor + pad) as i64);
-        }
-        y_cursor += primary_h;
-    }
-
-    // Heatmap grid
-    if let Some(ref heatmap_img) = heatmap {
-        imageops::overlay(&mut output, heatmap_img, 0, y_cursor as i64);
-        y_cursor += heatmap_h;
-    }
-
-    // Extra text strip
-    if let Some((tbuf, tw, th)) = extra_rendered
-        && tw > 0
-        && th > 0
-    {
-        fill_rect(
-            &mut output,
-            0,
-            y_cursor,
-            total_w,
-            extra_h,
-            [25, 25, 25, 255],
-        );
-        if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-            imageops::overlay(&mut output, &text_img, pad as i64, (y_cursor + pad) as i64);
+        if let Some(extra_img) = rasterized_image(ebuf, ew, eh) {
+            let extra_strip = layout::image(extra_img)
+                .padding(pad)
+                .background(extra_bg)
+                .fill_width();
+            col = col.child(extra_strip);
         }
     }
 
-    output
+    col.background(canvas_bg).render(grid_w)
 }
 
 /// Render a montage for images with different dimensions.
@@ -1006,8 +940,6 @@ fn render_mismatched_montage(
     actual: &RgbaImage,
     annotation: &AnnotationText,
 ) -> RgbaImage {
-    use crate::font;
-
     let (ew, eh) = expected.dimensions();
     let (aw, ah) = actual.dimensions();
     let amplification = options.amplification;
@@ -1112,274 +1044,34 @@ fn render_mismatched_montage(
 
     // Pixelate-upscale all four panels if tiny
     let min_panel_size = options.min_panel_size;
-    let up0;
-    let up1;
-    let up2;
-    let up3;
-    let panels: [&RgbaImage; 4] =
-        if min_panel_size > 0 && (canvas_w < min_panel_size || canvas_h < min_panel_size) {
-            up0 = pixelate_upscale(&panel_expected, min_panel_size);
-            up1 = pixelate_upscale(&panel_actual, min_panel_size);
-            up2 = pixelate_upscale(&panel_pixel_diff, min_panel_size);
-            up3 = pixelate_upscale(&panel_structural, min_panel_size);
-            [&up0, &up1, &up2, &up3]
-        } else {
-            [
-                &panel_expected,
-                &panel_actual,
-                &panel_pixel_diff,
-                &panel_structural,
-            ]
-        };
-
-    // ── From here: same 2x2 grid layout as render_montage_impl ──
-
-    let min_pad = (font::GLYPH_W * 3 / 10).max(8);
-    let pad = options.gap.max(min_pad);
-    let bg = Rgba([18, 18, 18, 255]);
-    let label_fg = [220, 220, 220, 255];
-    let label_bg = [40, 40, 40, 255];
-
-    let panel_w = panels[0].width();
-    let panel_h = panels[0].height();
-
-    // Label sizing: fit longest label within cell_w minus padding
-    // "PIXEL DIFF (RESIZED)" is 20 chars — use that as a floor
-    let label_inset = pad;
-    let label_area_w = panel_w.saturating_sub(label_inset * 2);
-    let expected_text: &str = options.expected_label.as_deref().unwrap_or("EXPECTED");
-    let actual_text: &str = options.actual_label.as_deref().unwrap_or("ACTUAL");
-    let longest_label = expected_text.len().max(actual_text.len()).max(20) as u32;
-    let label_char_h = ((label_area_w as f32 / longest_label as f32)
-        * (font::GLYPH_H as f32 / font::GLYPH_W as f32))
-        .floor() as u32;
-    let label_char_h = label_char_h.clamp(font::GLYPH_H, font::GLYPH_H * 3);
-
-    let plain_labels: [&str; 3] = [expected_text, actual_text, "PIXEL DIFF"];
-    let plain_images: Vec<(Vec<u8>, u32, u32)> = plain_labels
-        .iter()
-        .map(|label| {
-            let lines: Vec<(&str, [u8; 4])> = vec![(*label, label_fg)];
-            font::render_lines_fitted(&lines, label_bg, label_area_w)
-        })
-        .collect();
-
-    // ADD / REMOVE label for panel 3
-    let add_img = font::render_text_height("ADD", [255, 180, 80, 255], label_bg, label_char_h);
-    let rem_img = font::render_text_height("REMOVE", [80, 220, 220, 255], label_bg, label_char_h);
-    let ar_h = label_char_h;
-    let mut ar_rgba = RgbaImage::from_pixel(panel_w, ar_h, Rgba(label_bg));
-    if add_img.1 > 0
-        && add_img.2 > 0
-        && let Some(img) = RgbaImage::from_raw(add_img.1, add_img.2, add_img.0.clone())
-    {
-        imageops::overlay(&mut ar_rgba, &img, label_inset as i64, 0);
-    }
-    if rem_img.1 > 0
-        && rem_img.2 > 0
-        && let Some(img) = RgbaImage::from_raw(rem_img.1, rem_img.2, rem_img.0.clone())
-    {
-        let rx = panel_w.saturating_sub(rem_img.1 + label_inset);
-        imageops::overlay(&mut ar_rgba, &img, rx as i64, 0);
-    }
-    let ar_raw = ar_rgba.into_raw();
-
-    let label_images: Vec<(Vec<u8>, u32, u32)> = vec![
-        plain_images[0].clone(),
-        plain_images[1].clone(),
-        plain_images[2].clone(),
-        (ar_raw, panel_w, ar_h),
-    ];
-
-    let label_h = label_images.iter().map(|(_, _, h)| *h).max().unwrap_or(0) + 4;
-
-    // 2x2 grid
-    let cell_w = panel_w;
-    let cell_h = label_h + panel_h;
-    let grid_w = pad + cell_w + pad + cell_w + pad;
-    let grid_h = pad + cell_h + pad + cell_h + pad;
-
-    // Title text
-    let text_avail = grid_w.saturating_sub(pad * 2);
-    let title_rendered = annotation.title.as_ref().and_then(|t| {
-        if t.is_empty() {
-            return None;
-        }
-        let lines: Vec<(&str, [u8; 4])> = vec![(t.as_str(), [255, 255, 255, 255])];
-        Some(font::render_lines_fitted(
-            &lines,
-            [25, 25, 25, 255],
-            text_avail,
-        ))
-    });
-
-    // Primary text
-    let primary_rendered = if !annotation.primary_lines.is_empty() {
-        let line_refs: Vec<(&str, [u8; 4])> = annotation
-            .primary_lines
-            .iter()
-            .map(|(s, c)| (s.as_str(), *c))
-            .collect();
-        Some(font::render_lines_fitted(
-            &line_refs,
-            [30, 30, 30, 255],
-            text_avail,
-        ))
+    let panels = if min_panel_size > 0 && (canvas_w < min_panel_size || canvas_h < min_panel_size) {
+        [
+            pixelate_upscale(&panel_expected, min_panel_size),
+            pixelate_upscale(&panel_actual, min_panel_size),
+            pixelate_upscale(&panel_pixel_diff, min_panel_size),
+            pixelate_upscale(&panel_structural, min_panel_size),
+        ]
     } else {
-        None
+        [
+            panel_expected,
+            panel_actual,
+            panel_pixel_diff,
+            panel_structural,
+        ]
     };
 
-    // Heatmap
-    let heatmap = if has_differences && options.show_spatial_heatmap {
-        Some(render_heatmap_grid(&spatial, grid_w, pad))
-    } else {
-        None
-    };
-
-    // Extra text
-    let primary_line_h = primary_rendered
-        .as_ref()
-        .map_or(font::GLYPH_H, |(_, _, h)| {
-            let n = annotation.primary_lines.len().max(1) as u32;
-            *h / n
-        });
-    let extra_char_h = (primary_line_h * 7 / 10).max(font::GLYPH_H / 4);
-    let extra_rendered = if !annotation.extra.is_empty() {
-        Some(font::render_text_wrapped(
-            &annotation.extra,
-            COLOR_DETAIL,
-            [25, 25, 25, 255],
-            extra_char_h,
-            text_avail,
-        ))
-    } else {
-        None
-    };
-
-    let title_h = title_rendered.as_ref().map_or(0, |(_, _, h)| *h + pad * 2);
-    let primary_h = primary_rendered
-        .as_ref()
-        .map_or(0, |(_, _, h)| *h + pad * 2);
-    let heatmap_h = heatmap.as_ref().map_or(0, |img| img.height());
-    let extra_h = extra_rendered.as_ref().map_or(0, |(_, _, h)| *h + pad * 2);
-
-    let total_w = grid_w;
-    let total_h = grid_h + title_h + primary_h + heatmap_h + extra_h;
-
-    let mut output = RgbaImage::from_pixel(total_w, total_h, bg);
-
-    // Place 4 panels in 2x2 grid
-    for (i, panel) in panels.iter().enumerate() {
-        let col = (i % 2) as u32;
-        let row = (i / 2) as u32;
-        let x0 = pad + col * (cell_w + pad);
-        let y0 = pad + row * (cell_h + pad);
-
-        fill_rect(&mut output, x0, y0, cell_w, label_h, label_bg);
-
-        let (ref lbuf, lw, lh) = label_images[i];
-        if lw > 0 && lh > 0 {
-            let lx_off = (cell_w.saturating_sub(lw)) / 2;
-            let ly_off = (label_h.saturating_sub(lh)) / 2;
-            if let Some(label_img) = RgbaImage::from_raw(lw, lh, lbuf.clone()) {
-                imageops::overlay(
-                    &mut output,
-                    &label_img,
-                    (x0 + lx_off) as i64,
-                    (y0 + ly_off) as i64,
-                );
-            }
-        }
-
-        let pw = panel.width().min(cell_w);
-        let ph = panel.height().min(panel_h);
-        let cropped = imageops::crop_imm(*panel, 0, 0, pw, ph).to_image();
-        imageops::overlay(&mut output, &cropped, x0 as i64, (y0 + label_h) as i64);
-    }
-
-    // Title strip
-    let mut y_cursor = grid_h;
-    if let Some((tbuf, tw, th)) = title_rendered
-        && tw > 0
-        && th > 0
-    {
-        fill_rect(
-            &mut output,
-            0,
-            y_cursor,
-            total_w,
-            title_h,
-            [25, 25, 25, 255],
-        );
-        if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-            let tx = (total_w.saturating_sub(tw)) / 2;
-            imageops::overlay(&mut output, &text_img, tx as i64, (y_cursor + pad) as i64);
-        }
-        y_cursor += title_h;
-        fill_rect(
-            &mut output,
-            pad,
-            y_cursor.saturating_sub(1),
-            total_w - pad * 2,
-            1,
-            [60, 60, 60, 255],
-        );
-    }
-
-    // Primary text strip
-    if let Some((tbuf, tw, th)) = primary_rendered
-        && tw > 0
-        && th > 0
-    {
-        fill_rect(
-            &mut output,
-            0,
-            y_cursor,
-            total_w,
-            primary_h,
-            [30, 30, 30, 255],
-        );
-        if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-            let tx = (total_w.saturating_sub(tw)) / 2;
-            imageops::overlay(&mut output, &text_img, tx as i64, (y_cursor + pad) as i64);
-        }
-        y_cursor += primary_h;
-    }
-
-    // Heatmap
-    if let Some(ref heatmap_img) = heatmap {
-        imageops::overlay(&mut output, heatmap_img, 0, y_cursor as i64);
-        y_cursor += heatmap_h;
-    }
-
-    // Extra text
-    if let Some((tbuf, tw, th)) = extra_rendered
-        && tw > 0
-        && th > 0
-    {
-        fill_rect(
-            &mut output,
-            0,
-            y_cursor,
-            total_w,
-            extra_h,
-            [25, 25, 25, 255],
-        );
-        if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-            imageops::overlay(&mut output, &text_img, pad as i64, (y_cursor + pad) as i64);
-        }
-    }
-
-    output
+    compose_montage(panels, options, annotation, &spatial, has_differences, 20)
 }
 
-/// Render a 3x3 spatial heatmap grid image.
+/// Render an N×M spatial heatmap grid image.
 ///
 /// Each cell's background is tinted red proportional to its severity
-/// relative to the worst cell. Cell text shows `d:N` (max delta) and
-/// `P%` (percent differing). ADDED/MISSING tags shown when applicable.
+/// relative to the worst cell. Cell text shows `pct% Δmax_delta`,
+/// `zdsim:NNN` and an optional structural tag (ADDED / MISSING / changed).
+/// Composed via the [`crate::layout`] module.
 fn render_heatmap_grid(spatial: &SpatialAnalysis, total_w: u32, pad: u32) -> RgbaImage {
     use crate::font;
+    use crate::layout::{self, LayoutMod, Track, rgb};
 
     let cols = spatial.cols;
     let rows = spatial.rows;
@@ -1387,63 +1079,51 @@ fn render_heatmap_grid(spatial: &SpatialAnalysis, total_w: u32, pad: u32) -> Rgb
 
     let inner_w = total_w.saturating_sub(pad * 2);
     let cell_w = (inner_w.saturating_sub(cell_gap * (cols - 1))) / cols;
-    let cell_h = cell_w * 3 / 4; // slightly taller to fit 3 lines
-    let grid_px_w = cell_w * cols + cell_gap * (cols - 1);
-    let grid_px_h = cell_h * rows + cell_gap * (rows - 1);
-    let img_w = grid_px_w + pad * 2;
-    let img_h = grid_px_h + pad * 2;
+    let cell_h = cell_w * 3 / 4;
 
-    let mut img = RgbaImage::from_pixel(img_w, img_h, Rgba([18, 18, 18, 255]));
-
-    // Find worst cell for relative coloring
+    // Global severity scaling for background tinting.
     let max_severity = spatial
         .regions
         .iter()
         .map(|r| r.max_delta as f32 * r.pixels_differing as f32)
         .fold(0.0f32, f32::max)
-        .max(0.001); // avoid div by zero
+        .max(0.001);
+
+    // Cell-text padding (30% of one base char width per side, matching
+    // the original).
+    let cell_inset = font::GLYPH_W * 3 / 10;
+    let cell_text_w = cell_w.saturating_sub(cell_inset * 2);
+
+    let mut g = layout::grid()
+        .columns((0..cols).map(|_| Track::Px(cell_w)))
+        .rows((0..rows).map(|_| Track::Px(cell_h)))
+        .gap(cell_gap)
+        .padding(pad);
 
     for r in &spatial.regions {
-        let cx = pad + r.col * (cell_w + cell_gap);
-        let cy = pad + r.row * (cell_h + cell_gap);
-
-        // Background: red intensity by relative severity
         let severity = r.max_delta as f32 * r.pixels_differing as f32;
         let ratio = (severity / max_severity).clamp(0.0, 1.0);
-        let bg_r = (30.0 + ratio * 120.0) as u8; // 30..150
-        let bg_g = (30.0 - ratio * 20.0).max(10.0) as u8; // 30..10
+        let bg_r = (30.0 + ratio * 120.0) as u8;
+        let bg_g = ((30.0 - ratio * 20.0).max(10.0)) as u8;
         let bg_b = bg_g;
         let cell_bg = [bg_r, bg_g, bg_b, 255];
-        fill_rect(&mut img, cx, cy, cell_w, cell_h, cell_bg);
 
-        // Cell text — 3 lines for hot cells, "ok" for clean
-        // Padding: 30% of one character width on each side
+        // Pre-rasterize the cell text so the layout module's auto-fit
+        // formula can't shift char_h between measure and paint. The
+        // resulting Image leaf is centered inside a Layers stack on top
+        // of the cell-background fill.
         let pct = r.pixels_differing * 100.0;
-        let one_char_w = font::GLYPH_W; // base char width before scaling
-        let cell_inset = one_char_w * 3 / 10; // 30% of one char
-        let cell_text_w = cell_w.saturating_sub(cell_inset * 2);
-
-        if pct < 0.05 {
-            // Clean cell: small green "ok"
-            let ok_lines: Vec<(&str, [u8; 4])> = vec![("ok", COLOR_OK)];
-            if cell_text_w > 0 {
-                let (tbuf, tw, th) = font::render_lines_fitted(&ok_lines, cell_bg, cell_text_w);
-                if tw > 0 && th > 0 {
-                    let tx = cx + (cell_w.saturating_sub(tw)) / 2;
-                    let ty = cy + (cell_h.saturating_sub(th)) / 2;
-                    if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-                        imageops::overlay(&mut img, &text_img, tx as i64, ty as i64);
-                    }
-                }
-            }
+        let text_buf = if cell_text_w == 0 {
+            None
+        } else if pct < 0.05 {
+            let lines: Vec<(&str, [u8; 4])> = vec![("ok", COLOR_OK)];
+            let (tbuf, tw, th) = font::render_lines_fitted(&lines, cell_bg, cell_text_w);
+            (tw > 0 && th > 0)
+                .then(|| RgbaImage::from_raw(tw, th, tbuf))
+                .flatten()
         } else {
-            // Hot cell: 3 lines
-            // Line 1: "25% \u{0394}255"
             let line1 = format!("{:.0}% \u{0394}{}", pct, r.max_delta);
-            // Line 2: zdsim value for this cell (per-pixel severity)
-            let cell_zdsim = r.avg_delta / 255.0; // normalized
-            let line2 = format!("zdsim:{:.3}", cell_zdsim);
-            // Line 3: structural tag
+            let line2 = format!("zdsim:{:.3}", r.avg_delta / 255.0);
             let exp_has = r.expected_variance > 10.0;
             let act_has = r.actual_variance > 10.0;
             let line3 = if !exp_has && act_has {
@@ -1455,51 +1135,35 @@ fn render_heatmap_grid(spatial: &SpatialAnalysis, total_w: u32, pad: u32) -> Rgb
             } else {
                 ""
             };
-
             let text_fg = if ratio > 0.5 {
                 [255, 255, 255, 255]
             } else {
                 [220, 220, 220, 255]
             };
-            let mut cell_lines: Vec<(&str, [u8; 4])> =
+            let mut lines: Vec<(&str, [u8; 4])> =
                 vec![(&line1, text_fg), (&line2, [170, 170, 170, 255])];
             if !line3.is_empty() {
-                let tag_color = if line3 == "MISSING" {
-                    [255, 120, 120, 255] // red-ish
-                } else if line3 == "ADDED" {
-                    [255, 180, 80, 255] // orange
-                } else {
-                    [200, 200, 120, 255] // yellow
+                let tag_color = match line3 {
+                    "MISSING" => [255, 120, 120, 255],
+                    "ADDED" => [255, 180, 80, 255],
+                    _ => [200, 200, 120, 255],
                 };
-                cell_lines.push((line3, tag_color));
+                lines.push((line3, tag_color));
             }
+            let (tbuf, tw, th) = font::render_lines_fitted(&lines, cell_bg, cell_text_w);
+            (tw > 0 && th > 0)
+                .then(|| RgbaImage::from_raw(tw, th, tbuf))
+                .flatten()
+        };
 
-            if cell_text_w > 0 {
-                let (tbuf, tw, th) = font::render_lines_fitted(&cell_lines, cell_bg, cell_text_w);
-                if tw > 0 && th > 0 {
-                    let tx = cx + (cell_w.saturating_sub(tw)) / 2;
-                    let ty = cy + (cell_h.saturating_sub(th)) / 2;
-                    if let Some(text_img) = RgbaImage::from_raw(tw, th, tbuf) {
-                        imageops::overlay(&mut img, &text_img, tx as i64, ty as i64);
-                    }
-                }
-            }
+        let mut cell_layers = layout::layers().child(layout::fill(cell_bg));
+        if let Some(buf) = text_buf {
+            cell_layers = cell_layers.child(layout::image(buf).center());
         }
+        g = g.cell(r.col, r.row, cell_layers);
     }
 
-    img
-}
-
-/// Fill a rectangle with a solid color.
-fn fill_rect(img: &mut RgbaImage, x0: u32, y0: u32, w: u32, h: u32, color: [u8; 4]) {
-    let px = Rgba(color);
-    let img_w = img.width();
-    let img_h = img.height();
-    for y in y0..y0.saturating_add(h).min(img_h) {
-        for x in x0..x0.saturating_add(w).min(img_w) {
-            img.put_pixel(x, y, px);
-        }
-    }
+    g.background(rgb(18, 18, 18)).render(total_w)
 }
 
 /// Draw a 1px rectangular outline.
@@ -1829,6 +1493,206 @@ impl AnnotationText {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a synthetic 4-cell montage and verify the four label
+    /// strips are uniformly tall and horizontally aligned. Catches
+    /// regressions where ADD/REMOVE strip's height drifts away from
+    /// EXPECTED/ACTUAL/PIXEL DIFF strips' heights.
+    #[test]
+    fn montage_label_strips_have_uniform_height() {
+        let exp = RgbaImage::from_fn(96, 96, |x, y| {
+            Rgba([(x * 2) as u8, (y * 2) as u8, 128, 255])
+        });
+        let act = RgbaImage::from_fn(96, 96, |x, y| {
+            Rgba([(x * 2) as u8, (y * 2) as u8 + 30, 128, 255])
+        });
+        let opts = MontageOptions::default();
+        let canvas = opts.render(&exp, &act, &AnnotationText::empty());
+
+        // The label_bg color is rgb(40, 40, 40). Walk down the leftmost
+        // pixel column inside the panel area (x = 8 = pad) to collect
+        // the y-ranges where the column is label_bg. There should be
+        // two such ranges (one per row of cells), and they must have
+        // identical heights — otherwise the cells aren't aligned.
+        let label_bg = [40, 40, 40, 255];
+        let canvas_bg = [18, 18, 18, 255];
+        let pad = 8;
+        let mut runs: Vec<(u32, u32)> = Vec::new();
+        let mut start: Option<u32> = None;
+        for y in 0..canvas.height() {
+            let p = canvas.get_pixel(pad, y).0;
+            if p == label_bg {
+                if start.is_none() {
+                    start = Some(y);
+                }
+            } else if let Some(s) = start.take() {
+                runs.push((s, y - 1));
+            }
+        }
+        if let Some(s) = start {
+            runs.push((s, canvas.height() - 1));
+        }
+        assert!(
+            runs.len() >= 2,
+            "expected ≥2 label_bg runs (one per cell row), got {runs:?}"
+        );
+        // The first two runs are the two cell-row label strips.
+        let h0 = runs[0].1 - runs[0].0 + 1;
+        let h1 = runs[1].1 - runs[1].0 + 1;
+        assert_eq!(
+            h0, h1,
+            "label strip heights mismatch — row 0 = {h0}, row 1 = {h1} (runs = {runs:?})"
+        );
+
+        // Strip starts must be uniformly offset from the canvas top —
+        // the gap between row 0's strip end and row 1's strip start
+        // must equal panel_h + cell_row_gap (= panel_h + pad).
+        let between = runs[1].0 - runs[0].1 - 1;
+        // 96×96 image → pixelate to 288×288 → panel_h = 288. cell gap = pad.
+        let expected_between = 288 + pad;
+        assert_eq!(
+            between, expected_between,
+            "expected {expected_between} px between strips (panel + gap), got {between}"
+        );
+
+        // Sanity: above row 0 strip is canvas_bg (top padding).
+        let above = canvas.get_pixel(pad, runs[0].0 - 1).0;
+        assert_eq!(
+            above, canvas_bg,
+            "expected canvas_bg above row 0 strip, got {above:?}"
+        );
+    }
+
+    /// `LabelStyle::segmented_strip` uses `Track::FrMin { min_px: 6 }`
+    /// for the middle column, so left and right groups are guaranteed
+    /// to stay at least 6 px apart even when content widths exceed
+    /// the strip's inner width.
+    #[test]
+    fn segmented_strip_enforces_min_gap_under_overflow() {
+        use crate::layout::{LabelSegment, LabelStyle, LayoutMod, Size};
+
+        // 80-wide strip, with explicit char_h that makes ADD+REMOVE
+        // overflow on their own. FrMin(1, 6) forces a minimum gap.
+        let style = LabelStyle::default().with_char_h(20);
+        let strip = style
+            .segmented_strip(vec![
+                LabelSegment::left("ADDADDADD", [255, 180, 80, 255]),
+                LabelSegment::right("REMOVEREMOVE", [80, 220, 220, 255]),
+            ])
+            .width(crate::layout::SizeRule::Fixed(80))
+            .height(crate::layout::SizeRule::Fixed(30));
+        // Render and assert ADD's right edge ≤ REMOVE's left edge − 6.
+        let canvas = crate::layout::render(&strip, 80);
+        // Find the middle row, scan for orange (ADD) and cyan (REMOVE) clusters.
+        let mid_y = canvas.height() / 2;
+        let mut orange_xs = Vec::new();
+        let mut cyan_xs = Vec::new();
+        for x in 0..canvas.width() {
+            let p = canvas.get_pixel(x, mid_y).0;
+            // ADD is orange-ish (R high, G mid, B low).
+            if p[0] > 100 && p[1] > 80 && p[2] < 120 {
+                orange_xs.push(x);
+            }
+            // REMOVE is cyan-ish (R low, G high, B high).
+            if p[0] < 120 && p[1] > 100 && p[2] > 100 {
+                cyan_xs.push(x);
+            }
+        }
+        // We just want the rightmost orange and leftmost cyan.
+        if let (Some(&add_right), Some(&remove_left)) = (orange_xs.last(), cyan_xs.first()) {
+            let gap = remove_left as i32 - add_right as i32 - 1;
+            assert!(
+                gap >= 6,
+                "expected at least 6 px between ADD's right edge ({add_right}) and REMOVE's left ({remove_left}); got {gap}"
+            );
+        } else {
+            // If overflow caused full clipping, that's OK — but ensure
+            // we didn't render ADD/REMOVE on top of each other.
+            let _ = Size::new(80, 30);
+        }
+    }
+
+    /// Verify ADD and REMOVE labels in the structural-diff cell are
+    /// (a) both visible, (b) horizontally separated, (c) at the cell
+    /// row's vertical center.
+    #[test]
+    fn montage_add_remove_labels_are_separated() {
+        let exp = RgbaImage::from_fn(96, 96, |x, y| {
+            Rgba([(x * 2) as u8, (y * 2) as u8, 128, 255])
+        });
+        let act = RgbaImage::from_fn(96, 96, |x, y| {
+            Rgba([(x * 2) as u8, (y * 2) as u8 + 30, 128, 255])
+        });
+        let opts = MontageOptions::default();
+        let canvas = opts.render(&exp, &act, &AnnotationText::empty());
+
+        // ADD/REMOVE strip is in cell (1, 1). Find row-1 label strip
+        // by scanning down for the second label_bg run, then look at
+        // the right-cell column (x = pad + panel_w + pad + ... or just
+        // anywhere right of canvas mid).
+        let canvas_w = canvas.width();
+        let label_bg = [40, 40, 40, 255];
+        let mut runs: Vec<(u32, u32)> = Vec::new();
+        let mut start: Option<u32> = None;
+        for y in 0..canvas.height() {
+            let p = canvas.get_pixel(8, y).0;
+            if p == label_bg {
+                if start.is_none() {
+                    start = Some(y);
+                }
+            } else if let Some(s) = start.take() {
+                runs.push((s, y - 1));
+            }
+        }
+        assert!(runs.len() >= 2, "no row-1 label strip found");
+        let (y0, y1) = runs[1];
+        let mid_y = (y0 + y1) / 2;
+        let right_cell_mid_x = canvas_w * 3 / 4;
+
+        // Look for non-label-bg pixels in the right cell strip mid-row;
+        // should find ADD on the left half and REMOVE on the right
+        // half, with at least 20 px of label_bg between.
+        let strip_x_start = canvas_w / 2;
+        let strip_x_end = canvas_w - 8;
+        let mut text_xs: Vec<u32> = Vec::new();
+        for x in strip_x_start..strip_x_end {
+            let p = canvas.get_pixel(x, mid_y).0;
+            if p != label_bg && p != [18, 18, 18, 255] && p != [32, 32, 32, 255] {
+                text_xs.push(x);
+            }
+        }
+        // Group into clusters with > 20 px gap = separate words.
+        let clusters: Vec<(u32, u32)> = {
+            let mut out: Vec<(u32, u32)> = Vec::new();
+            let mut prev: Option<u32> = None;
+            for x in &text_xs {
+                if prev.is_none_or(|p| x - p > 20) {
+                    out.push((*x, *x));
+                } else {
+                    out.last_mut().unwrap().1 = *x;
+                }
+                prev = Some(*x);
+            }
+            out
+        };
+        assert!(
+            clusters.len() >= 2,
+            "expected ≥2 text clusters (ADD + REMOVE) in cell (1,1) mid-row, got {clusters:?}"
+        );
+        // First cluster (ADD) should be in the left half of the right
+        // cell; last cluster (REMOVE) in the right half.
+        let cell_mid = right_cell_mid_x;
+        assert!(
+            clusters[0].0 < cell_mid,
+            "ADD cluster should start left of right-cell mid (x={}), got {clusters:?}",
+            cell_mid
+        );
+        assert!(
+            clusters.last().unwrap().1 > cell_mid,
+            "REMOVE cluster should end right of right-cell mid (x={}), got {clusters:?}",
+            cell_mid
+        );
+    }
 
     #[test]
     fn diff_identical_images() {

--- a/zensim-regress/src/font.rs
+++ b/zensim-regress/src/font.rs
@@ -233,13 +233,11 @@ pub fn render_lines_fitted(
     if lines.is_empty() || max_width_px == 0 {
         return (vec![], 0, 0);
     }
-
-    let longest = lines.iter().map(|(s, _)| s.len()).max().unwrap_or(1) as u32;
-    // Compute char height that fits the longest line
-    let char_h = (max_width_px as f32 / longest as f32 * (BASE_CHAR_H as f32 / BASE_CHAR_W as f32))
-        .floor() as u32;
-    let char_h = char_h.clamp(BASE_CHAR_H / 4, BASE_CHAR_H);
-    let char_w = char_width_for_height(char_h);
+    let (char_w, char_h) = fit_char_h_for_lines(lines, max_width_px);
+    if char_w == 0 || char_h == 0 {
+        return (vec![], 0, 0);
+    }
+    let longest = lines.iter().map(|(s, _)| s.len()).max().unwrap_or(0) as u32;
 
     let out_w = longest * char_w;
     let out_h = lines.len() as u32 * char_h;
@@ -312,6 +310,14 @@ pub const GLYPH_W: u32 = BASE_CHAR_W;
 /// Base character height in pixels (before scaling).
 pub const GLYPH_H: u32 = BASE_CHAR_H;
 
+/// Typographic vertical-centering adjustment as a fraction of char
+/// height. Empirically derived from the embedded Consolas strip: the
+/// inked cap-mid (cap-top + baseline)/2 sits at ~42.6% of cell height,
+/// while the geometric cell mid is 50%. To make capitals appear
+/// visually centered when an enclosing layout uses geometric
+/// centering, shift the cell down by this fraction.
+pub const TYPO_CAP_MID_OFFSET: f32 = 0.074;
+
 // ─── Cheap measurement (no rasterization) ──────────────────────────────
 
 /// Return the `(w, h)` a [`render_text_height`] call would produce —
@@ -344,15 +350,39 @@ pub fn measure_text_wrapped(text: &str, target_char_h: u32, max_width_px: u32) -
 
 /// Return the `(w, h)` a [`render_lines_fitted`] call would produce.
 pub fn measure_lines_fitted(lines: &[(&str, [u8; 4])], max_width_px: u32) -> (u32, u32) {
+    let (char_w, char_h) = fit_char_h_for_lines(lines, max_width_px);
+    if char_w == 0 || char_h == 0 {
+        return (0, 0);
+    }
+    let longest = lines.iter().map(|(s, _)| s.len()).max().unwrap_or(0) as u32;
+    (longest * char_w, lines.len() as u32 * char_h)
+}
+
+/// Internal: derive `(char_w, char_h)` such that
+/// `longest * char_w ≤ max_width_px`. `char_w` is computed via
+/// [`char_width_for_height`] which rounds half-up, so the naive formula
+/// `floor(max_width_px / longest * BASE_H/BASE_W)` can overshoot by 1
+/// when char_w rounds up. We post-correct by decrementing `char_h`
+/// until `longest * char_w ≤ max_width_px`.
+pub(crate) fn fit_char_h_for_lines(lines: &[(&str, [u8; 4])], max_width_px: u32) -> (u32, u32) {
     if lines.is_empty() || max_width_px == 0 {
         return (0, 0);
     }
     let longest = lines.iter().map(|(s, _)| s.len()).max().unwrap_or(1) as u32;
-    let char_h = (max_width_px as f32 / longest as f32 * (BASE_CHAR_H as f32 / BASE_CHAR_W as f32))
+    if longest == 0 {
+        return (0, 0);
+    }
+    let mut char_h = (max_width_px as f32 / longest as f32
+        * (BASE_CHAR_H as f32 / BASE_CHAR_W as f32))
         .floor() as u32;
-    let char_h = char_h.clamp(BASE_CHAR_H / 4, BASE_CHAR_H);
-    let char_w = char_width_for_height(char_h);
-    (longest * char_w, lines.len() as u32 * char_h)
+    char_h = char_h.clamp(BASE_CHAR_H / 4, BASE_CHAR_H);
+    // Post-correct: char_width_for_height rounds half-up, so the
+    // initial char_h can produce `longest * char_w > max_width_px` by
+    // 1 character pixel. Decrement until it fits or we hit the floor.
+    while char_h > BASE_CHAR_H / 4 && longest * char_width_for_height(char_h) > max_width_px {
+        char_h -= 1;
+    }
+    (char_width_for_height(char_h), char_h)
 }
 
 #[cfg(test)]

--- a/zensim-regress/src/font.rs
+++ b/zensim-regress/src/font.rs
@@ -312,6 +312,49 @@ pub const GLYPH_W: u32 = BASE_CHAR_W;
 /// Base character height in pixels (before scaling).
 pub const GLYPH_H: u32 = BASE_CHAR_H;
 
+// ─── Cheap measurement (no rasterization) ──────────────────────────────
+
+/// Return the `(w, h)` a [`render_text_height`] call would produce —
+/// without actually rasterizing. Useful for two-pass layout where the
+/// measure pass needs sizes but the render pass will rasterize anyway.
+pub fn measure_text_height(text: &str, target_char_h: u32) -> (u32, u32) {
+    if target_char_h == 0 {
+        return (0, 0);
+    }
+    let lines: Vec<&str> = text.lines().collect();
+    let max_cols = lines.iter().map(|l| l.len()).max().unwrap_or(0) as u32;
+    let num_lines = lines.len() as u32;
+    if max_cols == 0 || num_lines == 0 {
+        return (0, 0);
+    }
+    let scaled_char_w = char_width_for_height(target_char_h);
+    (max_cols * scaled_char_w, num_lines * target_char_h)
+}
+
+/// Return the `(w, h)` a [`render_text_wrapped`] call would produce.
+pub fn measure_text_wrapped(text: &str, target_char_h: u32, max_width_px: u32) -> (u32, u32) {
+    if target_char_h == 0 || max_width_px == 0 {
+        return (0, 0);
+    }
+    let scaled_char_w = char_width_for_height(target_char_h);
+    let max_cols = (max_width_px / scaled_char_w.max(1)) as usize;
+    let wrapped = wrap_text(text, max_cols.max(1));
+    measure_text_height(&wrapped, target_char_h)
+}
+
+/// Return the `(w, h)` a [`render_lines_fitted`] call would produce.
+pub fn measure_lines_fitted(lines: &[(&str, [u8; 4])], max_width_px: u32) -> (u32, u32) {
+    if lines.is_empty() || max_width_px == 0 {
+        return (0, 0);
+    }
+    let longest = lines.iter().map(|(s, _)| s.len()).max().unwrap_or(1) as u32;
+    let char_h = (max_width_px as f32 / longest as f32 * (BASE_CHAR_H as f32 / BASE_CHAR_W as f32))
+        .floor() as u32;
+    let char_h = char_h.clamp(BASE_CHAR_H / 4, BASE_CHAR_H);
+    let char_w = char_width_for_height(char_h);
+    (longest * char_w, lines.len() as u32 * char_h)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/zensim-regress/src/layout.rs
+++ b/zensim-regress/src/layout.rs
@@ -1,0 +1,2205 @@
+//! Retained-tree layout for composing labeled image grids.
+//!
+//! v0 — CSS-flavored fluent API, two-pass measure → render. Designed for
+//! diff montages, heatmap cell grids, and any "labeled boxes of pixels and
+//! text" composition.
+//!
+//! # The model
+//!
+//! - **[`Node`]** is the IR — an enum of leaves (image, text, fill),
+//!   containers (row/column stacks, grid, layers), and modifiers (padding,
+//!   sizing, alignment, fit, background, border).
+//! - **Builders** ([`row`], [`column`], [`grid`], [`layers`]) wrap the IR
+//!   in fluent types that accept children and structural settings;
+//!   [`LayoutMod`] adds modifier methods to anything that converts to
+//!   [`Node`].
+//! - **Two passes:** [`Node::measure`] returns the size a node wants given
+//!   maximum constraints; [`Node::render`] paints into an existing canvas
+//!   at a given rect. [`render`] is the convenience entry point.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use zensim_regress::layout::*;
+//!
+//! let canvas = grid()
+//!     .areas(&[
+//!         "title title",
+//!         "exp   act ",
+//!         "pdiff sdiff",
+//!     ])
+//!     .row_heights([Track::Auto, Track::Px(panel_h), Track::Px(panel_h)])
+//!     .col_widths([Track::Fr(1), Track::Fr(1)])
+//!     .gap(8)
+//!     .padding(8)
+//!     .place("title", "FAILED — zdsim 0.13 > 0.01")
+//!     .place("exp",   image(expected).label("EXPECTED"))
+//!     .place("act",   image(actual).label("ACTUAL"))
+//!     .place("pdiff", image(pdiff).label("PIXEL DIFF"))
+//!     .place("sdiff", image(sdiff).label_segments(vec![
+//!         LabelSegment::left("ADD",    rgb(255, 180, 80)),
+//!         LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+//!     ], &LabelStyle::default()))
+//!     .background(hex("#121212"))
+//!     .render(800);
+//! ```
+//!
+//! # CSS correspondence
+//!
+//! | Layout API | CSS analogue |
+//! |---|---|
+//! | [`row()`] / [`column()`] | `display: flex; flex-direction: row | column` |
+//! | [`Stack::gap`] | `gap` |
+//! | [`Stack::justify`] | `justify-content` |
+//! | [`Stack::align_items`] | `align-items` |
+//! | [`grid()`] + [`Track`] | `display: grid; grid-template-columns/rows` |
+//! | [`Grid::areas`] | `grid-template-areas` |
+//! | [`Grid::span`] | `grid-column: span N` |
+//! | [`layers()`] | `position: absolute` siblings (z-stack) |
+//! | [`LayoutMod::padding`] | `padding` |
+//! | [`LayoutMod::width`]/[`LayoutMod::height`] | `width`/`height` |
+//! | [`LayoutMod::min_width`]/[`max_width`](LayoutMod::max_width) | `min-width`/`max-width` |
+//! | [`LayoutMod::aspect_ratio`] | `aspect-ratio` |
+//! | [`LayoutMod::align`] | `place-self` |
+//! | [`LayoutMod::fit`] | `object-fit` |
+//! | [`LayoutMod::background`] | `background-color` |
+//! | [`LayoutMod::border`] | `outline` (1-px) |
+
+use std::collections::HashMap;
+
+use image::{Rgba, RgbaImage, imageops};
+
+use crate::font;
+
+// ════════════════════════════════════════════════════════════════════════
+// Color
+// ════════════════════════════════════════════════════════════════════════
+
+/// RGBA color (straight alpha, the `image` crate's storage convention).
+pub type Color = [u8; 4];
+
+pub const WHITE: Color = [255, 255, 255, 255];
+pub const BLACK: Color = [0, 0, 0, 255];
+pub const TRANSPARENT: Color = [0, 0, 0, 0];
+
+/// Build an opaque RGB color.
+pub const fn rgb(r: u8, g: u8, b: u8) -> Color {
+    [r, g, b, 255]
+}
+
+/// Build an RGBA color.
+pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Color {
+    [r, g, b, a]
+}
+
+/// Parse a CSS-style hex color: `#RGB`, `#RRGGBB`, or `#RRGGBBAA`. The
+/// leading `#` is optional. Panics at compile time (or runtime, if not
+/// in const context) on malformed input.
+pub const fn hex(s: &str) -> Color {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let start = if len > 0 && bytes[0] == b'#' { 1 } else { 0 };
+    let n = len - start;
+
+    if n == 3 {
+        let r = hex1(bytes[start]) * 17;
+        let g = hex1(bytes[start + 1]) * 17;
+        let b = hex1(bytes[start + 2]) * 17;
+        [r, g, b, 255]
+    } else if n == 6 {
+        [
+            hex2(bytes[start], bytes[start + 1]),
+            hex2(bytes[start + 2], bytes[start + 3]),
+            hex2(bytes[start + 4], bytes[start + 5]),
+            255,
+        ]
+    } else if n == 8 {
+        [
+            hex2(bytes[start], bytes[start + 1]),
+            hex2(bytes[start + 2], bytes[start + 3]),
+            hex2(bytes[start + 4], bytes[start + 5]),
+            hex2(bytes[start + 6], bytes[start + 7]),
+        ]
+    } else {
+        panic!("invalid hex color literal — expected #RGB, #RRGGBB, or #RRGGBBAA")
+    }
+}
+
+const fn hex2(hi: u8, lo: u8) -> u8 {
+    hex1(hi) * 16 + hex1(lo)
+}
+
+const fn hex1(b: u8) -> u8 {
+    match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'f' => b - b'a' + 10,
+        b'A'..=b'F' => b - b'A' + 10,
+        _ => panic!("invalid hex digit"),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Geometry
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Size {
+    pub w: u32,
+    pub h: u32,
+}
+
+impl Size {
+    pub const fn new(w: u32, h: u32) -> Self {
+        Self { w, h }
+    }
+    pub const ZERO: Self = Self { w: 0, h: 0 };
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Rect {
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+}
+
+impl Rect {
+    pub const fn new(x: u32, y: u32, w: u32, h: u32) -> Self {
+        Self { x, y, w, h }
+    }
+    pub const fn size(&self) -> Size {
+        Size::new(self.w, self.h)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Insets {
+    pub left: u32,
+    pub top: u32,
+    pub right: u32,
+    pub bottom: u32,
+}
+
+impl Insets {
+    pub const fn all(v: u32) -> Self {
+        Self {
+            left: v,
+            top: v,
+            right: v,
+            bottom: v,
+        }
+    }
+    /// `Insets::xy(x, y)` — symmetric horizontal/vertical.
+    pub const fn xy(x: u32, y: u32) -> Self {
+        Self {
+            left: x,
+            top: y,
+            right: x,
+            bottom: y,
+        }
+    }
+    /// CSS shorthand order: top, right, bottom, left.
+    pub const fn each(top: u32, right: u32, bottom: u32, left: u32) -> Self {
+        Self {
+            top,
+            right,
+            bottom,
+            left,
+        }
+    }
+    pub const fn horizontal(&self) -> u32 {
+        self.left + self.right
+    }
+    pub const fn vertical(&self) -> u32 {
+        self.top + self.bottom
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Sizing & alignment enums
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum HAlign {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum VAlign {
+    Top,
+    #[default]
+    Center,
+    Bottom,
+}
+
+/// Main-axis distribution within a [`Stack`]. Mirrors CSS `justify-content`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum MainAlign {
+    #[default]
+    Start,
+    Center,
+    End,
+    /// Equal gaps between children, none at edges.
+    SpaceBetween,
+    /// Half-gaps at edges, full gaps between children.
+    SpaceAround,
+    /// Equal gaps everywhere (between, before, after).
+    SpaceEvenly,
+}
+
+/// Cross-axis alignment of children within a [`Stack`]. Mirrors CSS
+/// `align-items`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum CrossAlign {
+    #[default]
+    Start,
+    Center,
+    End,
+    /// Stretch each child to fill the cross axis.
+    Stretch,
+}
+
+/// How an [`image`] leaf scales into its allotted rect — CSS `object-fit`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum Fit {
+    /// Place at original size, clipped if larger than rect (CSS `none`).
+    #[default]
+    None,
+    /// Scale preserving aspect, fit entirely (letterbox).
+    Contain,
+    /// Scale preserving aspect, fill rect (crop overflow).
+    Cover,
+    /// Stretch to rect ignoring aspect.
+    Stretch,
+}
+
+/// Per-axis sizing rule for a node — analogous to CSS `width: auto/100%/<n>px`.
+///
+/// [`SizeRule::Grow`] is CSS `flex-grow: n` — among Grow children of a
+/// stack, remaining main-axis space is split proportionally to weight.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum SizeRule {
+    /// Hug content (CSS `auto`).
+    #[default]
+    Hug,
+    /// Fixed pixel size.
+    Fixed(u32),
+    /// Fill the parent constraint (CSS `100%`). Equivalent to `Grow(1)`
+    /// when used as the only flex rule, but inside a stack with mixed
+    /// `Grow`/`Fill` it consumes a single unit of weight.
+    Fill,
+    /// Weighted fill — CSS `flex-grow: n`.
+    Grow(u32),
+}
+
+impl SizeRule {
+    fn grow_weight(self) -> u32 {
+        match self {
+            SizeRule::Fill => 1,
+            SizeRule::Grow(w) => w,
+            _ => 0,
+        }
+    }
+}
+
+/// Grid track sizing — CSS `grid-template-columns` / `-rows`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Track {
+    /// Fixed pixel size.
+    Px(u32),
+    /// Fraction of remaining space (CSS `<n>fr`).
+    Fr(u32),
+    /// Hug the maximum content size in this track (CSS `auto` /
+    /// `min-content`).
+    Auto,
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Text
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Clone, Debug)]
+pub enum TextStyle {
+    /// One or more lines, each with its own color, sized so the longest
+    /// fits within the constraint width. [`font::render_lines_fitted`].
+    Lines(Vec<(String, Color)>),
+    /// Single line at a fixed character pixel-height. [`font::render_text_height`].
+    Fixed { text: String, fg: Color, char_h: u32 },
+    /// Word-wrapped text at a fixed character pixel-height.
+    /// [`font::render_text_wrapped`].
+    Wrapped {
+        text: String,
+        fg: Color,
+        char_h: u32,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct TextSpec {
+    pub style: TextStyle,
+    /// Background color the glyph rasterizer alpha-blends against — set
+    /// to match the strip behind the text for clean edges.
+    pub bg: Color,
+}
+
+impl TextSpec {
+    pub fn lines(lines: Vec<(impl Into<String>, Color)>, bg: Color) -> Self {
+        Self {
+            style: TextStyle::Lines(lines.into_iter().map(|(s, c)| (s.into(), c)).collect()),
+            bg,
+        }
+    }
+    pub fn fixed(text: impl Into<String>, fg: Color, bg: Color, char_h: u32) -> Self {
+        Self {
+            style: TextStyle::Fixed {
+                text: text.into(),
+                fg,
+                char_h,
+            },
+            bg,
+        }
+    }
+    pub fn wrapped(text: impl Into<String>, fg: Color, bg: Color, char_h: u32) -> Self {
+        Self {
+            style: TextStyle::Wrapped {
+                text: text.into(),
+                fg,
+                char_h,
+            },
+            bg,
+        }
+    }
+
+    fn rasterize(&self, max_w: u32) -> (Vec<u8>, u32, u32) {
+        if max_w == 0 {
+            return (vec![], 0, 0);
+        }
+        match &self.style {
+            TextStyle::Lines(lines) => {
+                let refs: Vec<(&str, Color)> =
+                    lines.iter().map(|(s, c)| (s.as_str(), *c)).collect();
+                font::render_lines_fitted(&refs, self.bg, max_w)
+            }
+            TextStyle::Fixed { text, fg, char_h } => {
+                font::render_text_height(text, *fg, self.bg, *char_h)
+            }
+            TextStyle::Wrapped { text, fg, char_h } => {
+                font::render_text_wrapped(text, *fg, self.bg, *char_h, max_w)
+            }
+        }
+    }
+
+    fn natural(&self, max_w: u32) -> Size {
+        if max_w == 0 {
+            return Size::ZERO;
+        }
+        let (w, h) = match &self.style {
+            TextStyle::Lines(lines) => {
+                let refs: Vec<(&str, Color)> =
+                    lines.iter().map(|(s, c)| (s.as_str(), *c)).collect();
+                font::measure_lines_fitted(&refs, max_w)
+            }
+            TextStyle::Fixed { text, char_h, .. } => font::measure_text_height(text, *char_h),
+            TextStyle::Wrapped { text, char_h, .. } => {
+                font::measure_text_wrapped(text, *char_h, max_w)
+            }
+        };
+        Size::new(w, h)
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Node IR
+// ════════════════════════════════════════════════════════════════════════
+
+/// The retained layout tree.
+///
+/// Construct via the free functions ([`image`], [`text`], [`line`],
+/// [`fill`], [`empty`]) and builders ([`row`], [`column`], [`grid`],
+/// [`layers`]); chain modifiers from the [`LayoutMod`] trait.
+#[derive(Clone, Debug)]
+pub enum Node {
+    // ── Leaves ────────────────────────────────────────────────────────
+    Empty,
+    Fill(Color),
+    Image(RgbaImage),
+    Text(TextSpec),
+
+    // ── Containers ────────────────────────────────────────────────────
+    Stack {
+        axis: Axis,
+        gap: u32,
+        justify: MainAlign,
+        align_items: CrossAlign,
+        children: Vec<Node>,
+    },
+    Grid {
+        cols: Vec<Track>,
+        rows: Vec<Track>,
+        gap: (u32, u32),
+        pad: u32,
+        cells: Vec<(GridSpan, Node)>,
+    },
+    Layers(Vec<Node>),
+
+    // ── Modifiers ─────────────────────────────────────────────────────
+    Padded {
+        insets: Insets,
+        child: Box<Node>,
+    },
+    Sized {
+        w: SizeRule,
+        h: SizeRule,
+        child: Box<Node>,
+    },
+    Constrain {
+        min_w: Option<u32>,
+        max_w: Option<u32>,
+        min_h: Option<u32>,
+        max_h: Option<u32>,
+        child: Box<Node>,
+    },
+    Aspect {
+        num: u32,
+        den: u32,
+        child: Box<Node>,
+    },
+    Align {
+        h: HAlign,
+        v: VAlign,
+        child: Box<Node>,
+    },
+    Fit {
+        mode: Fit,
+        child: Box<Node>,
+    },
+    Background {
+        color: Color,
+        child: Box<Node>,
+    },
+    Border {
+        color: Color,
+        child: Box<Node>,
+    },
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GridSpan {
+    pub col: u32,
+    pub row: u32,
+    pub colspan: u32,
+    pub rowspan: u32,
+}
+
+impl GridSpan {
+    pub const fn cell(col: u32, row: u32) -> Self {
+        Self {
+            col,
+            row,
+            colspan: 1,
+            rowspan: 1,
+        }
+    }
+    pub const fn span(col: u32, row: u32, colspan: u32, rowspan: u32) -> Self {
+        Self {
+            col,
+            row,
+            colspan,
+            rowspan,
+        }
+    }
+    fn cs(&self) -> u32 {
+        self.colspan.max(1)
+    }
+    fn rs(&self) -> u32 {
+        self.rowspan.max(1)
+    }
+}
+
+// ── Implicit conversions ───────────────────────────────────────────────
+
+impl From<&str> for Node {
+    /// Default: white text on black (pre-blended). For non-default
+    /// background, use [`text`] / [`line`] explicitly.
+    fn from(s: &str) -> Node {
+        Node::Text(TextSpec::lines(vec![(s.to_string(), WHITE)], BLACK))
+    }
+}
+impl From<String> for Node {
+    fn from(s: String) -> Node {
+        Node::Text(TextSpec::lines(vec![(s, WHITE)], BLACK))
+    }
+}
+impl From<RgbaImage> for Node {
+    fn from(img: RgbaImage) -> Node {
+        Node::Image(img)
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Free-function constructors
+// ════════════════════════════════════════════════════════════════════════
+
+pub fn empty() -> Node {
+    Node::Empty
+}
+pub fn fill(c: Color) -> Node {
+    Node::Fill(c)
+}
+pub fn image(img: RgbaImage) -> Node {
+    Node::Image(img)
+}
+pub fn text(spec: TextSpec) -> Node {
+    Node::Text(spec)
+}
+/// Single-line text on a transparent background, sized to fit the
+/// constraint width.
+pub fn line(s: impl Into<String>, fg: Color) -> Node {
+    Node::Text(TextSpec::lines(vec![(s.into(), fg)], TRANSPARENT))
+}
+
+pub fn row() -> Stack {
+    Stack::new(Axis::Horizontal)
+}
+pub fn column() -> Stack {
+    Stack::new(Axis::Vertical)
+}
+pub fn grid() -> Grid {
+    Grid::new()
+}
+pub fn layers() -> Layers {
+    Layers::new()
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Stack builder
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Clone, Debug)]
+pub struct Stack {
+    axis: Axis,
+    gap: u32,
+    justify: MainAlign,
+    align_items: CrossAlign,
+    children: Vec<Node>,
+}
+
+impl Stack {
+    pub fn new(axis: Axis) -> Self {
+        Self {
+            axis,
+            gap: 0,
+            justify: MainAlign::Start,
+            align_items: CrossAlign::Start,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn gap(mut self, g: u32) -> Self {
+        self.gap = g;
+        self
+    }
+    pub fn justify(mut self, j: MainAlign) -> Self {
+        self.justify = j;
+        self
+    }
+    pub fn align_items(mut self, a: CrossAlign) -> Self {
+        self.align_items = a;
+        self
+    }
+    pub fn child(mut self, c: impl Into<Node>) -> Self {
+        self.children.push(c.into());
+        self
+    }
+    pub fn children<I, N>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = N>,
+        N: Into<Node>,
+    {
+        self.children.extend(items.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl From<Stack> for Node {
+    fn from(s: Stack) -> Node {
+        Node::Stack {
+            axis: s.axis,
+            gap: s.gap,
+            justify: s.justify,
+            align_items: s.align_items,
+            children: s.children,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Grid builder
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Clone, Debug, Default)]
+pub struct Grid {
+    cols: Vec<Track>,
+    rows: Vec<Track>,
+    gap: (u32, u32),
+    pad: u32,
+    cells: Vec<(GridSpan, Node)>,
+    areas: HashMap<String, GridSpan>,
+}
+
+impl Grid {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn columns(mut self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.cols = tracks.into_iter().collect();
+        self
+    }
+    pub fn rows(mut self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.rows = tracks.into_iter().collect();
+        self
+    }
+    /// Alias for [`Grid::columns`] — reads better paired with [`row_heights`].
+    pub fn col_widths(self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.columns(tracks)
+    }
+    /// Alias for [`Grid::rows`].
+    pub fn row_heights(self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.rows(tracks)
+    }
+    /// Equal-weight fr columns: shorthand for `vec![Track::Fr(1); n]`.
+    pub fn cols(mut self, n: u32) -> Self {
+        self.cols = (0..n).map(|_| Track::Fr(1)).collect();
+        self
+    }
+    /// Equal-weight fr rows.
+    pub fn equal_rows(mut self, n: u32) -> Self {
+        self.rows = (0..n).map(|_| Track::Fr(1)).collect();
+        self
+    }
+
+    pub fn gap(mut self, g: u32) -> Self {
+        self.gap = (g, g);
+        self
+    }
+    pub fn gap_xy(mut self, x: u32, y: u32) -> Self {
+        self.gap = (x, y);
+        self
+    }
+    pub fn padding(mut self, p: u32) -> Self {
+        self.pad = p;
+        self
+    }
+
+    pub fn cell(mut self, col: u32, row: u32, n: impl Into<Node>) -> Self {
+        self.cells.push((GridSpan::cell(col, row), n.into()));
+        self
+    }
+    pub fn span(
+        mut self,
+        col: u32,
+        row: u32,
+        colspan: u32,
+        rowspan: u32,
+        n: impl Into<Node>,
+    ) -> Self {
+        self.cells
+            .push((GridSpan::span(col, row, colspan, rowspan), n.into()));
+        self
+    }
+
+    /// Define named areas by an ASCII-art template — like CSS
+    /// `grid-template-areas`. Each row is a string of whitespace-separated
+    /// tokens; `.` is empty. All rows must have the same column count.
+    /// Repeated tokens form a single area whose bounding box is computed.
+    ///
+    /// If `cols`/`rows` haven't been set explicitly, this also infers
+    /// equal-weight Fr tracks from the template's dimensions.
+    pub fn areas(mut self, rows: &[&str]) -> Self {
+        if rows.is_empty() {
+            return self;
+        }
+        let row_tokens: Vec<Vec<&str>> = rows
+            .iter()
+            .map(|r| r.split_whitespace().collect())
+            .collect();
+        let cols_count = row_tokens[0].len() as u32;
+        for (i, r) in row_tokens.iter().enumerate() {
+            assert_eq!(
+                r.len() as u32,
+                cols_count,
+                "Grid::areas row {i} has {} cols, expected {cols_count}",
+                r.len()
+            );
+        }
+        let rows_count = rows.len() as u32;
+
+        // name → (col_min, row_min, col_max, row_max)
+        let mut bbox: HashMap<String, (u32, u32, u32, u32)> = HashMap::new();
+        for (r, line) in row_tokens.iter().enumerate() {
+            for (c, tok) in line.iter().enumerate() {
+                if *tok == "." {
+                    continue;
+                }
+                let key = (*tok).to_string();
+                let entry = bbox
+                    .entry(key)
+                    .or_insert((c as u32, r as u32, c as u32, r as u32));
+                entry.0 = entry.0.min(c as u32);
+                entry.1 = entry.1.min(r as u32);
+                entry.2 = entry.2.max(c as u32);
+                entry.3 = entry.3.max(r as u32);
+            }
+        }
+        self.areas = bbox
+            .into_iter()
+            .map(|(name, (c0, r0, c1, r1))| {
+                (
+                    name,
+                    GridSpan::span(c0, r0, c1 - c0 + 1, r1 - r0 + 1),
+                )
+            })
+            .collect();
+
+        if self.cols.is_empty() {
+            self.cols = (0..cols_count).map(|_| Track::Fr(1)).collect();
+        }
+        if self.rows.is_empty() {
+            self.rows = (0..rows_count).map(|_| Track::Fr(1)).collect();
+        }
+        self
+    }
+
+    /// Place a child in a named area defined by [`Grid::areas`].
+    /// Panics if `name` is unknown.
+    pub fn place(mut self, name: &str, n: impl Into<Node>) -> Self {
+        let span = *self
+            .areas
+            .get(name)
+            .unwrap_or_else(|| panic!("Grid::place: no area named {name:?}"));
+        self.cells.push((span, n.into()));
+        self
+    }
+}
+
+impl From<Grid> for Node {
+    fn from(g: Grid) -> Node {
+        Node::Grid {
+            cols: g.cols,
+            rows: g.rows,
+            gap: g.gap,
+            pad: g.pad,
+            cells: g.cells,
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Layers builder
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Clone, Debug, Default)]
+pub struct Layers {
+    children: Vec<Node>,
+}
+
+impl Layers {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn child(mut self, c: impl Into<Node>) -> Self {
+        self.children.push(c.into());
+        self
+    }
+    pub fn children<I, N>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = N>,
+        N: Into<Node>,
+    {
+        self.children.extend(items.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl From<Layers> for Node {
+    fn from(l: Layers) -> Node {
+        Node::Layers(l.children)
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// LayoutMod — fluent modifiers on anything that converts to Node
+// ════════════════════════════════════════════════════════════════════════
+
+/// Modifier methods on any layout node or builder. Auto-imported via
+/// `use zensim_regress::layout::*;`.
+pub trait LayoutMod: Sized {
+    fn into_node(self) -> Node;
+
+    // ── Padding (CSS `padding`) ────────────────────────────────────────
+    fn padding(self, v: u32) -> Node {
+        wrap_padded(self.into_node(), Insets::all(v))
+    }
+    fn padding_xy(self, x: u32, y: u32) -> Node {
+        wrap_padded(self.into_node(), Insets::xy(x, y))
+    }
+    /// CSS shorthand order: top, right, bottom, left.
+    fn padding_each(self, t: u32, r: u32, b: u32, l: u32) -> Node {
+        wrap_padded(self.into_node(), Insets::each(t, r, b, l))
+    }
+
+    // ── Sizing (CSS `width`, `height`) ────────────────────────────────
+    fn width(self, r: SizeRule) -> Node {
+        wrap_sized(self.into_node(), r, SizeRule::Hug)
+    }
+    fn height(self, r: SizeRule) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Hug, r)
+    }
+    /// Fixed `(w, h)`.
+    fn size(self, w: u32, h: u32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Fixed(w), SizeRule::Fixed(h))
+    }
+    fn fill_width(self) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Fill, SizeRule::Hug)
+    }
+    fn fill_height(self) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Hug, SizeRule::Fill)
+    }
+    fn fill(self) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Fill, SizeRule::Fill)
+    }
+    /// Weighted main-axis grow (CSS `flex-grow`). Only meaningful inside
+    /// a stack with other Grow/Fill children.
+    fn grow(self, weight: u32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Grow(weight), SizeRule::Hug)
+    }
+
+    // ── Min/Max constraints (CSS `min-width` etc.) ────────────────────
+    fn min_width(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), Some(n), None, None, None)
+    }
+    fn max_width(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), None, Some(n), None, None)
+    }
+    fn min_height(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), None, None, Some(n), None)
+    }
+    fn max_height(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), None, None, None, Some(n))
+    }
+
+    /// CSS `aspect-ratio: <num> / <den>`.
+    fn aspect_ratio(self, num: u32, den: u32) -> Node {
+        Node::Aspect {
+            num: num.max(1),
+            den: den.max(1),
+            child: Box::new(self.into_node()),
+        }
+    }
+
+    // ── Alignment (CSS `place-self`) ──────────────────────────────────
+    fn align(self, h: HAlign, v: VAlign) -> Node {
+        Node::Align {
+            h,
+            v,
+            child: Box::new(self.into_node()),
+        }
+    }
+    fn center(self) -> Node {
+        self.align(HAlign::Center, VAlign::Center)
+    }
+    fn align_h(self, h: HAlign) -> Node {
+        self.align(h, VAlign::Top)
+    }
+    fn align_v(self, v: VAlign) -> Node {
+        self.align(HAlign::Left, v)
+    }
+
+    // ── Image fit (CSS `object-fit`) ──────────────────────────────────
+    fn fit(self, mode: Fit) -> Node {
+        Node::Fit {
+            mode,
+            child: Box::new(self.into_node()),
+        }
+    }
+    fn fit_contain(self) -> Node {
+        self.fit(Fit::Contain)
+    }
+    fn fit_cover(self) -> Node {
+        self.fit(Fit::Cover)
+    }
+    fn fit_stretch(self) -> Node {
+        self.fit(Fit::Stretch)
+    }
+
+    // ── Painting ──────────────────────────────────────────────────────
+    fn background(self, c: Color) -> Node {
+        Node::Background {
+            color: c,
+            child: Box::new(self.into_node()),
+        }
+    }
+    fn border(self, c: Color) -> Node {
+        Node::Border {
+            color: c,
+            child: Box::new(self.into_node()),
+        }
+    }
+
+    // ── Label shortcuts ───────────────────────────────────────────────
+    fn label(self, s: impl Into<String>) -> Node {
+        self.label_styled(s, &LabelStyle::default())
+    }
+    fn label_styled(self, s: impl Into<String>, style: &LabelStyle) -> Node {
+        column().gap(0).child(style.strip(s)).child(self.into_node()).into()
+    }
+    fn label_segments(self, segments: Vec<LabelSegment>, style: &LabelStyle) -> Node {
+        column()
+            .gap(0)
+            .child(style.segmented_strip(segments))
+            .child(self.into_node())
+            .into()
+    }
+
+    /// Render this tree into an [`RgbaImage`] of width `max_w`. Convenience
+    /// for `render(&node, max_w)` when you have a builder in hand.
+    fn render(self, max_w: u32) -> RgbaImage {
+        render(&self.into_node(), max_w)
+    }
+}
+
+fn wrap_padded(child: Node, insets: Insets) -> Node {
+    Node::Padded {
+        insets,
+        child: Box::new(child),
+    }
+}
+fn wrap_sized(child: Node, w: SizeRule, h: SizeRule) -> Node {
+    Node::Sized {
+        w,
+        h,
+        child: Box::new(child),
+    }
+}
+fn wrap_constrain(
+    child: Node,
+    min_w: Option<u32>,
+    max_w: Option<u32>,
+    min_h: Option<u32>,
+    max_h: Option<u32>,
+) -> Node {
+    Node::Constrain {
+        min_w,
+        max_w,
+        min_h,
+        max_h,
+        child: Box::new(child),
+    }
+}
+
+impl LayoutMod for Node {
+    fn into_node(self) -> Node {
+        self
+    }
+}
+impl LayoutMod for Stack {
+    fn into_node(self) -> Node {
+        self.into()
+    }
+}
+impl LayoutMod for Grid {
+    fn into_node(self) -> Node {
+        self.into()
+    }
+}
+impl LayoutMod for Layers {
+    fn into_node(self) -> Node {
+        self.into()
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Measurement
+// ════════════════════════════════════════════════════════════════════════
+
+impl Node {
+    /// Measure this node given the maximum available `(w, h)`. Returns
+    /// the size the node wants, always clamped to `max`.
+    pub fn measure(&self, max: Size) -> Size {
+        let raw = self.measure_raw(max);
+        Size::new(raw.w.min(max.w), raw.h.min(max.h))
+    }
+
+    fn measure_raw(&self, max: Size) -> Size {
+        match self {
+            Node::Empty => Size::ZERO,
+            Node::Fill(_) => Size::ZERO,
+            Node::Image(img) => Size::new(img.width(), img.height()),
+            Node::Text(spec) => spec.natural(max.w),
+
+            Node::Stack {
+                axis,
+                gap,
+                children,
+                ..
+            } => measure_stack(*axis, *gap, children, max),
+
+            Node::Grid {
+                cols,
+                rows,
+                gap,
+                pad,
+                cells,
+            } => measure_grid(cols, rows, *gap, *pad, cells, max),
+
+            Node::Layers(children) => {
+                let mut out = Size::ZERO;
+                for c in children {
+                    let s = c.measure(max);
+                    out.w = out.w.max(s.w);
+                    out.h = out.h.max(s.h);
+                }
+                out
+            }
+
+            Node::Padded { insets, child } => {
+                let inner_max = Size::new(
+                    max.w.saturating_sub(insets.horizontal()),
+                    max.h.saturating_sub(insets.vertical()),
+                );
+                let inner = child.measure(inner_max);
+                Size::new(inner.w + insets.horizontal(), inner.h + insets.vertical())
+            }
+
+            Node::Sized { w, h, child } => {
+                let child_size = child.measure(max);
+                let out_w = match w {
+                    SizeRule::Hug => child_size.w,
+                    SizeRule::Fill | SizeRule::Grow(_) => max.w,
+                    SizeRule::Fixed(v) => *v,
+                };
+                let out_h = match h {
+                    SizeRule::Hug => child_size.h,
+                    SizeRule::Fill | SizeRule::Grow(_) => max.h,
+                    SizeRule::Fixed(v) => *v,
+                };
+                Size::new(out_w, out_h)
+            }
+
+            Node::Constrain {
+                min_w,
+                max_w,
+                min_h,
+                max_h,
+                child,
+            } => {
+                let child_max = Size::new(
+                    max_w.map_or(max.w, |v| v.min(max.w)),
+                    max_h.map_or(max.h, |v| v.min(max.h)),
+                );
+                let s = child.measure(child_max);
+                Size::new(
+                    s.w.max(min_w.unwrap_or(0))
+                        .min(max_w.unwrap_or(u32::MAX))
+                        .min(max.w),
+                    s.h.max(min_h.unwrap_or(0))
+                        .min(max_h.unwrap_or(u32::MAX))
+                        .min(max.h),
+                )
+            }
+
+            Node::Aspect { num, den, child } => measure_aspect(*num, *den, child, max),
+
+            Node::Align { child, .. } => child.measure(max),
+            Node::Fit { child, .. } => child.measure(max),
+            Node::Background { child, .. } => child.measure(max),
+            Node::Border { child, .. } => child.measure(max),
+        }
+    }
+}
+
+fn measure_stack(axis: Axis, gap: u32, children: &[Node], max: Size) -> Size {
+    if children.is_empty() {
+        return Size::ZERO;
+    }
+    let n = children.len() as u32;
+    let total_gap = gap.saturating_mul(n.saturating_sub(1));
+
+    let (main_max, cross_max) = match axis {
+        Axis::Horizontal => (max.w.saturating_sub(total_gap), max.h),
+        Axis::Vertical => (max.h.saturating_sub(total_gap), max.w),
+    };
+    let child_max = match axis {
+        Axis::Horizontal => Size::new(main_max, cross_max),
+        Axis::Vertical => Size::new(cross_max, main_max),
+    };
+
+    let mut main = 0u32;
+    let mut cross = 0u32;
+    for c in children {
+        let s = c.measure(child_max);
+        let (m, x) = match axis {
+            Axis::Horizontal => (s.w, s.h),
+            Axis::Vertical => (s.h, s.w),
+        };
+        main = main.saturating_add(m);
+        cross = cross.max(x);
+    }
+    main = main.saturating_add(total_gap);
+    match axis {
+        Axis::Horizontal => Size::new(main, cross),
+        Axis::Vertical => Size::new(cross, main),
+    }
+}
+
+fn measure_grid(
+    cols: &[Track],
+    rows: &[Track],
+    gap: (u32, u32),
+    pad: u32,
+    cells: &[(GridSpan, Node)],
+    max: Size,
+) -> Size {
+    if cols.is_empty() || rows.is_empty() {
+        return Size::ZERO;
+    }
+    let inner_w = max
+        .w
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.0.saturating_mul(cols.len().saturating_sub(1) as u32));
+    let inner_h = max
+        .h
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.1.saturating_mul(rows.len().saturating_sub(1) as u32));
+    let col_widths = solve_tracks(cols, inner_w, |c| {
+        max_natural_in_track(cells, c, true, gap, max)
+    });
+    let row_heights = solve_tracks(rows, inner_h, |r| {
+        max_natural_in_track(cells, r, false, gap, max)
+    });
+    let total_w =
+        pad * 2 + col_widths.iter().sum::<u32>() + gap.0.saturating_mul(cols.len() as u32 - 1);
+    let total_h =
+        pad * 2 + row_heights.iter().sum::<u32>() + gap.1.saturating_mul(rows.len() as u32 - 1);
+    Size::new(total_w.min(max.w), total_h.min(max.h))
+}
+
+/// For Auto-track sizing: find the max natural size of any cell whose
+/// span includes track index `idx` along the given axis, divided by the
+/// span length so a 2-col-spanning child contributes half its width to
+/// each spanned column.
+fn max_natural_in_track(
+    cells: &[(GridSpan, Node)],
+    idx: u32,
+    is_col: bool,
+    gap: (u32, u32),
+    max: Size,
+) -> u32 {
+    let mut out = 0u32;
+    for (span, child) in cells {
+        let (start, len) = if is_col {
+            (span.col, span.cs())
+        } else {
+            (span.row, span.rs())
+        };
+        if idx < start || idx >= start + len {
+            continue;
+        }
+        // Measure with a generous constraint — auto tracks should hug.
+        let s = child.measure(max);
+        let dim = if is_col { s.w } else { s.h };
+        // Subtract internal gaps when distributing across span.
+        let internal_gap = if is_col { gap.0 } else { gap.1 };
+        let spread = dim
+            .saturating_sub(internal_gap.saturating_mul(len.saturating_sub(1)))
+            .div_ceil(len.max(1));
+        out = out.max(spread);
+    }
+    out
+}
+
+/// Solve track sizes given total available space along that axis.
+///
+/// 1. Px tracks consume their fixed size.
+/// 2. Auto tracks consume their content size (via `auto_size` callback).
+/// 3. Remaining space is distributed among Fr tracks proportionally to
+///    their fr weight.
+#[allow(clippy::manual_checked_ops)]
+fn solve_tracks(tracks: &[Track], available: u32, auto_size: impl Fn(u32) -> u32) -> Vec<u32> {
+    let mut sizes = vec![0u32; tracks.len()];
+    let mut consumed = 0u32;
+    let mut total_fr = 0u32;
+
+    for (i, t) in tracks.iter().enumerate() {
+        match t {
+            Track::Px(v) => {
+                sizes[i] = *v;
+                consumed = consumed.saturating_add(*v);
+            }
+            Track::Auto => {
+                let v = auto_size(i as u32);
+                sizes[i] = v;
+                consumed = consumed.saturating_add(v);
+            }
+            Track::Fr(w) => {
+                total_fr = total_fr.saturating_add(*w);
+            }
+        }
+    }
+    if total_fr > 0 {
+        let remainder = available.saturating_sub(consumed);
+        // First (n-1) Fr tracks get floor share; last Fr track gets the
+        // remainder so we don't lose pixels to integer division.
+        let mut allotted = 0u32;
+        let mut last_fr_idx: Option<usize> = None;
+        for (i, t) in tracks.iter().enumerate() {
+            if let Track::Fr(w) = t {
+                let share = remainder * *w / total_fr;
+                sizes[i] = share;
+                allotted = allotted.saturating_add(share);
+                last_fr_idx = Some(i);
+            }
+        }
+        if let Some(i) = last_fr_idx {
+            sizes[i] = sizes[i].saturating_add(remainder.saturating_sub(allotted));
+        }
+    }
+    sizes
+}
+
+fn measure_aspect(num: u32, den: u32, child: &Node, max: Size) -> Size {
+    let s = child.measure(max);
+    let cw = s.w.max(1);
+    let ch = s.h.max(1);
+    let h_from_w = cw * den / num;
+    let w_from_h = ch * num / den;
+    if h_from_w <= max.h && cw <= max.w && h_from_w >= ch {
+        Size::new(cw, h_from_w)
+    } else if w_from_h <= max.w && ch <= max.h {
+        Size::new(w_from_h, ch)
+    } else {
+        // Both candidates exceed; scale to fit max while preserving ratio.
+        let h_from_max_w = max.w * den / num;
+        if h_from_max_w <= max.h {
+            Size::new(max.w, h_from_max_w)
+        } else {
+            Size::new(max.h * num / den, max.h)
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Rendering
+// ════════════════════════════════════════════════════════════════════════
+
+/// Render `tree` against `max_w`. The canvas height is derived from the
+/// tree's measured height. The default canvas background is opaque black.
+pub fn render(tree: &Node, max_w: u32) -> RgbaImage {
+    render_with(tree, max_w, BLACK)
+}
+
+/// As [`render`], with a custom default canvas background.
+pub fn render_with(tree: &Node, max_w: u32, bg: Color) -> RgbaImage {
+    let root_max = Size::new(max_w, u32::MAX / 2);
+    let s = tree.measure(root_max);
+    let mut canvas = RgbaImage::from_pixel(s.w.max(1), s.h.max(1), Rgba(bg));
+    tree.paint(Rect::new(0, 0, s.w, s.h), &mut canvas);
+    canvas
+}
+
+/// Render the tree into an existing canvas at `rect`.
+pub fn render_into(tree: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    tree.paint(rect, canvas);
+}
+
+impl Node {
+    fn paint(&self, rect: Rect, canvas: &mut RgbaImage) {
+        if rect.w == 0 || rect.h == 0 {
+            return;
+        }
+        match self {
+            Node::Empty => {}
+            Node::Fill(c) => fill_rect(canvas, rect, *c),
+            Node::Image(img) => render_image(img, Fit::None, rect, canvas),
+            Node::Text(spec) => render_text(spec, rect, canvas),
+
+            Node::Stack {
+                axis,
+                gap,
+                justify,
+                align_items,
+                children,
+            } => render_stack(*axis, *gap, *justify, *align_items, children, rect, canvas),
+
+            Node::Grid {
+                cols,
+                rows,
+                gap,
+                pad,
+                cells,
+            } => render_grid(cols, rows, *gap, *pad, cells, rect, canvas),
+
+            Node::Layers(children) => {
+                for c in children {
+                    c.paint(rect, canvas);
+                }
+            }
+
+            Node::Padded { insets, child } => {
+                let inner = Rect::new(
+                    rect.x.saturating_add(insets.left),
+                    rect.y.saturating_add(insets.top),
+                    rect.w.saturating_sub(insets.horizontal()),
+                    rect.h.saturating_sub(insets.vertical()),
+                );
+                child.paint(inner, canvas);
+            }
+            Node::Sized { child, .. } => child.paint(rect, canvas),
+            Node::Constrain { child, .. } => child.paint(rect, canvas),
+            Node::Aspect { child, .. } => child.paint(rect, canvas),
+            Node::Align { h, v, child } => {
+                let child_size = child.measure(rect.size());
+                let x_off = match h {
+                    HAlign::Left => 0,
+                    HAlign::Center => rect.w.saturating_sub(child_size.w) / 2,
+                    HAlign::Right => rect.w.saturating_sub(child_size.w),
+                };
+                let y_off = match v {
+                    VAlign::Top => 0,
+                    VAlign::Center => rect.h.saturating_sub(child_size.h) / 2,
+                    VAlign::Bottom => rect.h.saturating_sub(child_size.h),
+                };
+                let inner = Rect::new(
+                    rect.x.saturating_add(x_off),
+                    rect.y.saturating_add(y_off),
+                    child_size.w.min(rect.w),
+                    child_size.h.min(rect.h),
+                );
+                child.paint(inner, canvas);
+            }
+            Node::Fit { mode, child } => {
+                if let Node::Image(img) = child.as_ref() {
+                    render_image(img, *mode, rect, canvas);
+                } else {
+                    child.paint(rect, canvas);
+                }
+            }
+            Node::Background { color, child } => {
+                fill_rect(canvas, rect, *color);
+                child.paint(rect, canvas);
+            }
+            Node::Border { color, child } => {
+                child.paint(rect, canvas);
+                draw_rect_border(canvas, rect, *color);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::manual_checked_ops)]
+fn render_stack(
+    axis: Axis,
+    gap: u32,
+    justify: MainAlign,
+    align_items: CrossAlign,
+    children: &[Node],
+    rect: Rect,
+    canvas: &mut RgbaImage,
+) {
+    if children.is_empty() {
+        return;
+    }
+    let n = children.len() as u32;
+    let total_gap = gap.saturating_mul(n.saturating_sub(1));
+    let (main_avail, cross_avail) = match axis {
+        Axis::Horizontal => (rect.w.saturating_sub(total_gap), rect.h),
+        Axis::Vertical => (rect.h.saturating_sub(total_gap), rect.w),
+    };
+    let child_max = match axis {
+        Axis::Horizontal => Size::new(main_avail, cross_avail),
+        Axis::Vertical => Size::new(cross_avail, main_avail),
+    };
+
+    // Gather grow weights (Fill + Grow) and natural main sizes.
+    let mut weights: Vec<u32> = vec![0; children.len()];
+    let mut measured: Vec<Size> = Vec::with_capacity(children.len());
+    let mut used_main = 0u32;
+    let mut total_weight = 0u32;
+    for (i, c) in children.iter().enumerate() {
+        let s = c.measure(child_max);
+        let w = main_grow_weight(c, axis);
+        weights[i] = w;
+        total_weight = total_weight.saturating_add(w);
+        let main_dim = match axis {
+            Axis::Horizontal => s.w,
+            Axis::Vertical => s.h,
+        };
+        if w == 0 {
+            used_main = used_main.saturating_add(main_dim);
+        }
+        measured.push(s);
+    }
+
+    let remainder = main_avail.saturating_sub(used_main);
+
+    // Compute per-child main size.
+    let mut main_sizes: Vec<u32> = vec![0; children.len()];
+    let mut allotted = 0u32;
+    let mut last_flex_idx: Option<usize> = None;
+    for i in 0..children.len() {
+        if weights[i] > 0 {
+            let share = if total_weight > 0 {
+                remainder * weights[i] / total_weight
+            } else {
+                0
+            };
+            main_sizes[i] = share;
+            allotted = allotted.saturating_add(share);
+            last_flex_idx = Some(i);
+        } else {
+            main_sizes[i] = match axis {
+                Axis::Horizontal => measured[i].w,
+                Axis::Vertical => measured[i].h,
+            };
+        }
+    }
+    if let Some(i) = last_flex_idx {
+        main_sizes[i] = main_sizes[i].saturating_add(remainder.saturating_sub(allotted));
+    }
+
+    let total_children_main: u32 = main_sizes.iter().sum();
+    let leftover = main_avail.saturating_sub(total_children_main);
+
+    // Compute starting offset and inter-child spacing per justify.
+    let (mut cursor, lead_pad, extra_gap) = match justify {
+        MainAlign::Start => (0u32, 0u32, 0u32),
+        MainAlign::Center => (leftover / 2, 0, 0),
+        MainAlign::End => (leftover, 0, 0),
+        MainAlign::SpaceBetween if n > 1 => (0, 0, leftover / (n - 1)),
+        MainAlign::SpaceBetween => (0, 0, 0),
+        MainAlign::SpaceAround => {
+            let unit = if n > 0 { leftover / n } else { 0 };
+            (unit / 2, 0, unit)
+        }
+        MainAlign::SpaceEvenly => {
+            let unit = leftover / (n + 1);
+            (unit, 0, unit)
+        }
+    };
+    cursor = cursor.saturating_add(lead_pad);
+    cursor = cursor.saturating_add(match axis {
+        Axis::Horizontal => rect.x,
+        Axis::Vertical => rect.y,
+    });
+
+    for (i, child) in children.iter().enumerate() {
+        let m_size = main_sizes[i];
+        let cross_natural = match axis {
+            Axis::Horizontal => measured[i].h,
+            Axis::Vertical => measured[i].w,
+        };
+        let cross_size = match align_items {
+            CrossAlign::Stretch => cross_avail,
+            _ => cross_natural.min(cross_avail),
+        };
+        let cross_off = match align_items {
+            CrossAlign::Start | CrossAlign::Stretch => 0,
+            CrossAlign::Center => cross_avail.saturating_sub(cross_size) / 2,
+            CrossAlign::End => cross_avail.saturating_sub(cross_size),
+        };
+
+        let child_rect = match axis {
+            Axis::Horizontal => Rect::new(cursor, rect.y + cross_off, m_size, cross_size),
+            Axis::Vertical => Rect::new(rect.x + cross_off, cursor, cross_size, m_size),
+        };
+        child.paint(child_rect, canvas);
+
+        cursor = cursor.saturating_add(m_size);
+        if i + 1 < children.len() {
+            cursor = cursor.saturating_add(gap).saturating_add(extra_gap);
+        }
+    }
+}
+
+fn main_grow_weight(node: &Node, axis: Axis) -> u32 {
+    match node {
+        Node::Sized { w, h, .. } => {
+            let r = match axis {
+                Axis::Horizontal => *w,
+                Axis::Vertical => *h,
+            };
+            r.grow_weight()
+        }
+        _ => 0,
+    }
+}
+
+fn render_grid(
+    cols: &[Track],
+    rows: &[Track],
+    gap: (u32, u32),
+    pad: u32,
+    cells: &[(GridSpan, Node)],
+    rect: Rect,
+    canvas: &mut RgbaImage,
+) {
+    if cols.is_empty() || rows.is_empty() {
+        return;
+    }
+    let inner_w = rect
+        .w
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.0.saturating_mul(cols.len().saturating_sub(1) as u32));
+    let inner_h = rect
+        .h
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.1.saturating_mul(rows.len().saturating_sub(1) as u32));
+    let col_widths = solve_tracks(cols, inner_w, |c| {
+        max_natural_in_track(cells, c, true, gap, rect.size())
+    });
+    let row_heights = solve_tracks(rows, inner_h, |r| {
+        max_natural_in_track(cells, r, false, gap, rect.size())
+    });
+
+    // Cumulative offsets.
+    let mut col_off = vec![0u32; cols.len() + 1];
+    for i in 0..cols.len() {
+        col_off[i + 1] = col_off[i] + col_widths[i] + if i + 1 < cols.len() { gap.0 } else { 0 };
+    }
+    let mut row_off = vec![0u32; rows.len() + 1];
+    for i in 0..rows.len() {
+        row_off[i + 1] = row_off[i] + row_heights[i] + if i + 1 < rows.len() { gap.1 } else { 0 };
+    }
+
+    for (span, child) in cells {
+        if span.col >= cols.len() as u32 || span.row >= rows.len() as u32 {
+            continue;
+        }
+        let cs = span.cs().min(cols.len() as u32 - span.col);
+        let rs = span.rs().min(rows.len() as u32 - span.row);
+        let x0 = rect.x + pad + col_off[span.col as usize];
+        let y0 = rect.y + pad + row_off[span.row as usize];
+        let x1 = rect.x + pad + col_off[(span.col + cs) as usize].saturating_sub(gap.0);
+        let y1 = rect.y + pad + row_off[(span.row + rs) as usize].saturating_sub(gap.1);
+        let w = x1.saturating_sub(x0);
+        let h = y1.saturating_sub(y0);
+        child.paint(Rect::new(x0, y0, w, h), canvas);
+    }
+}
+
+// ── Leaf renderers ─────────────────────────────────────────────────────
+
+fn render_image(img: &RgbaImage, mode: Fit, rect: Rect, canvas: &mut RgbaImage) {
+    if rect.w == 0 || rect.h == 0 {
+        return;
+    }
+    let (iw, ih) = (img.width(), img.height());
+    if iw == 0 || ih == 0 {
+        return;
+    }
+    let scaled: Option<RgbaImage> = match mode {
+        Fit::None => None,
+        Fit::Stretch if (iw, ih) != (rect.w, rect.h) => Some(imageops::resize(
+            img,
+            rect.w,
+            rect.h,
+            imageops::FilterType::Triangle,
+        )),
+        Fit::Stretch => None,
+        Fit::Contain | Fit::Cover => {
+            let sx = rect.w as f32 / iw as f32;
+            let sy = rect.h as f32 / ih as f32;
+            let s = if matches!(mode, Fit::Contain) {
+                sx.min(sy)
+            } else {
+                sx.max(sy)
+            };
+            let nw = (iw as f32 * s).round().max(1.0) as u32;
+            let nh = (ih as f32 * s).round().max(1.0) as u32;
+            Some(imageops::resize(
+                img,
+                nw,
+                nh,
+                imageops::FilterType::Triangle,
+            ))
+        }
+    };
+
+    let (src, sw, sh) = match &scaled {
+        Some(s) => (s, s.width(), s.height()),
+        None => (img, iw, ih),
+    };
+
+    let x_off = (rect.w.saturating_sub(sw)) / 2;
+    let y_off = (rect.h.saturating_sub(sh)) / 2;
+
+    if sw <= rect.w && sh <= rect.h {
+        imageops::overlay(
+            canvas,
+            src,
+            rect.x.saturating_add(x_off) as i64,
+            rect.y.saturating_add(y_off) as i64,
+        );
+    } else {
+        let crop_x = (sw.saturating_sub(rect.w)) / 2;
+        let crop_y = (sh.saturating_sub(rect.h)) / 2;
+        let cw = rect.w.min(sw);
+        let ch = rect.h.min(sh);
+        let cropped = imageops::crop_imm(src, crop_x, crop_y, cw, ch).to_image();
+        imageops::overlay(canvas, &cropped, rect.x as i64, rect.y as i64);
+    }
+}
+
+fn render_text(spec: &TextSpec, rect: Rect, canvas: &mut RgbaImage) {
+    let (buf, w, h) = spec.rasterize(rect.w);
+    if w == 0 || h == 0 {
+        return;
+    }
+    let Some(img) = RgbaImage::from_raw(w, h, buf) else {
+        return;
+    };
+    imageops::overlay(canvas, &img, rect.x as i64, rect.y as i64);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Drawing primitives
+// ════════════════════════════════════════════════════════════════════════
+
+pub fn fill_rect(img: &mut RgbaImage, rect: Rect, color: Color) {
+    let px = Rgba(color);
+    let img_w = img.width();
+    let img_h = img.height();
+    let x_end = rect.x.saturating_add(rect.w).min(img_w);
+    let y_end = rect.y.saturating_add(rect.h).min(img_h);
+    for y in rect.y..y_end {
+        for x in rect.x..x_end {
+            img.put_pixel(x, y, px);
+        }
+    }
+}
+
+pub fn draw_rect_border(img: &mut RgbaImage, rect: Rect, color: Color) {
+    if rect.w == 0 || rect.h == 0 {
+        return;
+    }
+    let px = Rgba(color);
+    let img_w = img.width();
+    let img_h = img.height();
+    let x_end = rect.x.saturating_add(rect.w).min(img_w);
+    let y_end = rect.y.saturating_add(rect.h).min(img_h);
+    for x in rect.x..x_end {
+        if rect.y < img_h {
+            img.put_pixel(x, rect.y, px);
+        }
+        let bot = y_end.saturating_sub(1);
+        if bot < img_h && bot > rect.y {
+            img.put_pixel(x, bot, px);
+        }
+    }
+    for y in rect.y..y_end {
+        if rect.x < img_w {
+            img.put_pixel(rect.x, y, px);
+        }
+        let right = x_end.saturating_sub(1);
+        if right < img_w && right > rect.x {
+            img.put_pixel(right, y, px);
+        }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Label styling
+// ════════════════════════════════════════════════════════════════════════
+
+#[derive(Clone, Debug)]
+pub struct LabelStyle {
+    pub fg: Color,
+    pub bg: Color,
+    pub align: HAlign,
+    pub padding: Insets,
+    /// `None` → auto-fit width via [`font::measure_lines_fitted`].
+    pub char_h: Option<u32>,
+}
+
+impl Default for LabelStyle {
+    fn default() -> Self {
+        Self {
+            fg: rgb(220, 220, 220),
+            bg: rgb(40, 40, 40),
+            align: HAlign::Center,
+            padding: Insets::xy(8, 2),
+            char_h: None,
+        }
+    }
+}
+
+impl LabelStyle {
+    pub fn with_fg(mut self, fg: Color) -> Self {
+        self.fg = fg;
+        self
+    }
+    pub fn with_bg(mut self, bg: Color) -> Self {
+        self.bg = bg;
+        self
+    }
+    pub fn with_align(mut self, align: HAlign) -> Self {
+        self.align = align;
+        self
+    }
+    pub fn with_padding(mut self, padding: Insets) -> Self {
+        self.padding = padding;
+        self
+    }
+    pub fn with_char_h(mut self, char_h: u32) -> Self {
+        self.char_h = Some(char_h);
+        self
+    }
+
+    fn strip(&self, s: impl Into<String>) -> Node {
+        let inner = match self.char_h {
+            Some(h) => text(TextSpec::fixed(s, self.fg, self.bg, h)),
+            None => text(TextSpec::lines(vec![(s.into(), self.fg)], self.bg)),
+        };
+        let mut inner: Node = inner.align_h(self.align);
+        if self.padding != Insets::default() {
+            inner = wrap_padded(inner, self.padding);
+        }
+        inner.background(self.bg).fill_width()
+    }
+
+    fn segmented_strip(&self, segments: Vec<LabelSegment>) -> Node {
+        let mut l = layers().child(fill(self.bg));
+        for seg in segments {
+            let txt = match self.char_h.or(seg.char_h) {
+                Some(h) => text(TextSpec::fixed(seg.text, seg.fg, self.bg, h)),
+                None => text(TextSpec::lines(vec![(seg.text, seg.fg)], self.bg)),
+            };
+            l = l.child(txt.align(seg.align, VAlign::Center).padding_xy(
+                self.padding.left.max(self.padding.right),
+                self.padding.top.max(self.padding.bottom),
+            ));
+        }
+        l.fill_width()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LabelSegment {
+    pub text: String,
+    pub fg: Color,
+    pub align: HAlign,
+    pub char_h: Option<u32>,
+}
+
+impl LabelSegment {
+    pub fn left(text: impl Into<String>, fg: Color) -> Self {
+        Self {
+            text: text.into(),
+            fg,
+            align: HAlign::Left,
+            char_h: None,
+        }
+    }
+    pub fn right(text: impl Into<String>, fg: Color) -> Self {
+        Self {
+            text: text.into(),
+            fg,
+            align: HAlign::Right,
+            char_h: None,
+        }
+    }
+    pub fn center(text: impl Into<String>, fg: Color) -> Self {
+        Self {
+            text: text.into(),
+            fg,
+            align: HAlign::Center,
+            char_h: None,
+        }
+    }
+    pub fn with_char_h(mut self, h: u32) -> Self {
+        self.char_h = Some(h);
+        self
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Tests
+// ════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid(w: u32, h: u32, c: Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    // ── Color ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn hex_3_digit() {
+        assert_eq!(hex("#abc"), [0xaa, 0xbb, 0xcc, 255]);
+    }
+    #[test]
+    fn hex_6_digit() {
+        assert_eq!(hex("#1a2b3c"), [0x1a, 0x2b, 0x3c, 255]);
+    }
+    #[test]
+    fn hex_8_digit() {
+        assert_eq!(hex("#11223344"), [0x11, 0x22, 0x33, 0x44]);
+    }
+    #[test]
+    fn hex_no_hash() {
+        assert_eq!(hex("ff0080"), [0xff, 0x00, 0x80, 255]);
+    }
+    #[test]
+    fn rgb_helper_is_opaque() {
+        assert_eq!(rgb(10, 20, 30), [10, 20, 30, 255]);
+    }
+
+    // ── Geometry / measurement ─────────────────────────────────────────
+
+    #[test]
+    fn empty_measures_zero() {
+        assert_eq!(empty().measure(Size::new(100, 100)), Size::ZERO);
+    }
+    #[test]
+    fn image_natural_size() {
+        let n: Node = solid(50, 30, [255, 0, 0, 255]).into();
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(50, 30));
+    }
+    #[test]
+    fn padded_grows_by_insets() {
+        let n = image(solid(50, 30, WHITE)).padding(10);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(70, 50));
+    }
+    #[test]
+    fn size_overrides() {
+        let n = image(solid(50, 30, WHITE)).size(100, 80);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(100, 80));
+    }
+    #[test]
+    fn fill_width_consumes_max() {
+        let n = image(solid(50, 30, WHITE)).fill_width();
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(200, 30));
+    }
+
+    // ── Stack ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn column_sums_main_max_cross() {
+        let n = column()
+            .gap(2)
+            .child(image(solid(10, 10, WHITE)))
+            .child(image(solid(20, 5, WHITE)));
+        assert_eq!(n.into_node().measure(Size::new(100, 100)), Size::new(20, 17));
+    }
+    #[test]
+    fn row_sums_main_max_cross() {
+        let n = row()
+            .gap(4)
+            .child(image(solid(10, 10, WHITE)))
+            .child(image(solid(20, 5, WHITE)));
+        assert_eq!(n.into_node().measure(Size::new(100, 100)), Size::new(34, 10));
+    }
+
+    #[test]
+    fn align_items_center_centers_in_cross() {
+        let small = image(solid(10, 10, [255, 0, 0, 255]));
+        let big = image(solid(40, 40, [0, 0, 0, 255]));
+        let n = column()
+            .align_items(CrossAlign::Center)
+            .child(small)
+            .child(big)
+            .render(40);
+        // Small centered within 40 cross-width: red pixel at x=15..25, y=0..9.
+        assert_eq!(n.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(n.get_pixel(0, 5), &Rgba([0, 0, 0, 255]));
+    }
+
+    #[test]
+    fn align_items_stretch_fills_cross() {
+        // Empty has 0 natural height — give the strip explicit height so
+        // it has a main-axis size to paint into.
+        let strip = empty().background([255, 0, 0, 255]).height(SizeRule::Fixed(5));
+        let big = image(solid(40, 40, BLACK));
+        let img = column()
+            .align_items(CrossAlign::Stretch)
+            .child(strip)
+            .child(big)
+            .size(40, 45)
+            .render(40);
+        // Strip stretched to width 40; first row red.
+        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(39, 0), &Rgba([255, 0, 0, 255]));
+    }
+
+    #[test]
+    fn justify_space_between() {
+        let a = image(solid(10, 10, [255, 0, 0, 255]));
+        let b = image(solid(10, 10, [0, 0, 255, 255]));
+        let img = row()
+            .justify(MainAlign::SpaceBetween)
+            .child(a)
+            .child(b)
+            .size(50, 10)
+            .render(50);
+        // a at x=0..10 (red), b at x=40..50 (blue).
+        assert_eq!(img.get_pixel(5, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(45, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grow_weights_distribute_remainder() {
+        // Two children: a hug (10px), and a Grow(2). Total stack 60px main.
+        // Hug consumes 10; remainder 50; grow gets all 50.
+        let hug = image(solid(10, 10, [255, 0, 0, 255]));
+        let grow = empty().background([0, 0, 255, 255]).grow(2).fill_height();
+        let img = row()
+            .align_items(CrossAlign::Stretch)
+            .child(hug)
+            .child(grow)
+            .size(60, 10)
+            .render(60);
+        assert_eq!(img.get_pixel(5, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grow_weights_split_2_to_1() {
+        let a = empty().background([255, 0, 0, 255]).grow(2);
+        let b = empty().background([0, 0, 255, 255]).grow(1);
+        let img = row()
+            .align_items(CrossAlign::Stretch)
+            .child(a)
+            .child(b)
+            .size(60, 10)
+            .render(60);
+        // a gets ~40, b gets ~20.
+        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    // ── Grid ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn grid_uniform_fr_fills_constraint() {
+        let img = grid()
+            .cols(2)
+            .equal_rows(2)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 255, 0, 255]).fill())
+            .cell(0, 1, empty().background([0, 0, 255, 255]).fill())
+            .cell(1, 1, empty().background([255, 255, 0, 255]).fill())
+            .size(80, 80)
+            .render(80);
+        assert_eq!(img.get_pixel(20, 20), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(60, 20), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(20, 60), &Rgba([0, 0, 255, 255]));
+        assert_eq!(img.get_pixel(60, 60), &Rgba([255, 255, 0, 255]));
+    }
+
+    #[test]
+    fn grid_track_px_takes_fixed_size() {
+        let img = grid()
+            .columns([Track::Px(20), Track::Fr(1)])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(100, 10)
+            .render(100);
+        // Px(20) = red on x<20, Fr fills x>=20 with blue.
+        assert_eq!(img.get_pixel(10, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grid_track_auto_hugs_content() {
+        let img = grid()
+            .columns([Track::Auto, Track::Fr(1)])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, image(solid(15, 10, [255, 0, 0, 255])))
+            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(100, 10)
+            .render(100);
+        // Auto col = 15 wide (red), Fr fills rest (blue).
+        assert_eq!(img.get_pixel(7, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grid_areas_parses_template() {
+        let img = grid()
+            .areas(&["title title", "exp   act"])
+            .row_heights([Track::Px(10), Track::Px(20)])
+            .gap(0)
+            .place("title", empty().background([255, 0, 0, 255]).fill())
+            .place("exp", empty().background([0, 255, 0, 255]).fill())
+            .place("act", empty().background([0, 0, 255, 255]).fill())
+            .size(40, 30)
+            .render(40);
+        // Title row spans 0..40, height 10 → red at top.
+        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        // exp/act split at x=20, y=10..30.
+        assert_eq!(img.get_pixel(10, 20), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(30, 20), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grid_span_via_areas() {
+        let img = grid()
+            .areas(&["banner banner", "a a"])
+            .equal_rows(2)
+            .gap(0)
+            .place("banner", empty().background([0, 255, 0, 255]).fill())
+            .place("a", empty().background([255, 0, 0, 255]).fill())
+            .size(40, 40)
+            .render(40);
+        // Banner spans both columns of row 0.
+        assert_eq!(img.get_pixel(10, 10), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(30, 10), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(20, 30), &Rgba([255, 0, 0, 255]));
+    }
+
+    // ── Layers / modifiers ─────────────────────────────────────────────
+
+    #[test]
+    fn layers_painters_order() {
+        let bg = empty().background([255, 0, 0, 255]).fill();
+        let dot = image(solid(4, 4, [0, 255, 0, 255])).center();
+        let img = layers().child(bg).child(dot).size(20, 20).render(20);
+        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(10, 10), &Rgba([0, 255, 0, 255]));
+    }
+
+    #[test]
+    fn align_centers_in_oversized_rect() {
+        let img = image(solid(20, 10, [255, 255, 0, 255]))
+            .center()
+            .size(100, 60)
+            .render(100);
+        assert_eq!(img.get_pixel(50, 30), &Rgba([255, 255, 0, 255]));
+        assert_eq!(img.get_pixel(0, 0), &Rgba([0, 0, 0, 255]));
+    }
+
+    #[test]
+    fn background_paints_first() {
+        let img = empty().background([10, 20, 30, 255]).size(20, 20).render(20);
+        assert_eq!(img.get_pixel(5, 5), &Rgba([10, 20, 30, 255]));
+    }
+
+    #[test]
+    fn border_paints_outline() {
+        let img = empty()
+            .background(BLACK)
+            .border(WHITE)
+            .size(10, 10)
+            .render(10);
+        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
+        assert_eq!(img.get_pixel(9, 0), &Rgba([255, 255, 255, 255]));
+        assert_eq!(img.get_pixel(5, 5), &Rgba([0, 0, 0, 255]));
+    }
+
+    #[test]
+    fn fit_contain_letterboxes() {
+        let img = image(solid(20, 10, [255, 0, 0, 255]))
+            .fit_contain()
+            .size(40, 40)
+            .render(40);
+        assert_eq!(img.get_pixel(20, 0), &Rgba([0, 0, 0, 255]));
+        assert_eq!(img.get_pixel(20, 20), &Rgba([255, 0, 0, 255]));
+    }
+
+    // ── min/max/aspect ─────────────────────────────────────────────────
+
+    #[test]
+    fn min_width_grows_to_minimum() {
+        let n = image(solid(10, 10, WHITE)).min_width(50);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(50, 10));
+    }
+    #[test]
+    fn max_width_caps_natural() {
+        let n = image(solid(80, 10, WHITE)).max_width(40);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(40, 10));
+    }
+    #[test]
+    fn aspect_ratio_16_9_from_width() {
+        let n = image(solid(160, 50, WHITE)).aspect_ratio(16, 9);
+        // cw=160, h_from_w = 160*9/16 = 90 → (160, 90)
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(160, 90));
+    }
+
+    // ── Text ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn text_lines_measures_match_render() {
+        let spec = TextSpec::lines(
+            vec![("HELLO".to_string(), WHITE), ("WORLD!".to_string(), WHITE)],
+            BLACK,
+        );
+        let measured = spec.natural(200);
+        let (_, w, h) = spec.rasterize(200);
+        assert_eq!(measured, Size::new(w, h));
+    }
+    #[test]
+    fn from_str_makes_text_node() {
+        let n: Node = "hello".into();
+        assert!(matches!(n, Node::Text(_)));
+    }
+
+    // ── Label ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn label_default_strip_above_image() {
+        let img = image(solid(40, 40, [255, 0, 0, 255])).label("EXPECTED");
+        let s = img.measure(Size::new(400, 400));
+        assert!(s.h > 40);
+    }
+    #[test]
+    fn label_styled_uses_provided_bg() {
+        let style = LabelStyle::default()
+            .with_bg(rgb(100, 0, 0))
+            .with_fg(rgb(255, 255, 0));
+        let canvas = image(solid(40, 40, [255, 0, 0, 255]))
+            .label_styled("HELLO", &style)
+            .width(SizeRule::Fixed(40))
+            .render(40);
+        assert_eq!(canvas.get_pixel(0, 0), &Rgba([100, 0, 0, 255]));
+    }
+
+    // ── Builder fluency smoke tests ────────────────────────────────────
+
+    #[test]
+    fn builder_chain_produces_node() {
+        let _: Node = column()
+            .gap(8)
+            .align_items(CrossAlign::Center)
+            .child("hi")
+            .child(image(solid(10, 10, WHITE)))
+            .padding(4)
+            .background(hex("#123456"));
+    }
+    #[test]
+    fn implicit_str_to_text_in_builder() {
+        let n: Node = row().child("a").child("b").into();
+        if let Node::Stack { children, .. } = n {
+            assert_eq!(children.len(), 2);
+            assert!(matches!(children[0], Node::Text(_)));
+        } else {
+            panic!("expected Stack");
+        }
+    }
+}

--- a/zensim-regress/src/layout.rs
+++ b/zensim-regress/src/layout.rs
@@ -14,8 +14,8 @@
 //!   [`LayoutMod`] adds modifier methods to anything that converts to
 //!   [`Node`].
 //! - **Two passes:** [`Node::measure`] returns the size a node wants given
-//!   maximum constraints; [`Node::render`] paints into an existing canvas
-//!   at a given rect. [`render`] is the convenience entry point.
+//!   maximum constraints; [`render`] lays out and paints into a fresh
+//!   canvas.
 //!
 //! # Example
 //!
@@ -44,2143 +44,188 @@
 //!     .render(800);
 //! ```
 //!
-//! # CSS correspondence
+//! # File layout
 //!
-//! | Layout API | CSS analogue |
+//! | Concern | File |
 //! |---|---|
-//! | [`row()`] / [`column()`] | `display: flex; flex-direction: row | column` |
-//! | [`Stack::gap`] | `gap` |
-//! | [`Stack::justify`] | `justify-content` |
-//! | [`Stack::align_items`] | `align-items` |
-//! | [`grid()`] + [`Track`] | `display: grid; grid-template-columns/rows` |
-//! | [`Grid::areas`] | `grid-template-areas` |
-//! | [`Grid::span`] | `grid-column: span N` |
-//! | [`layers()`] | `position: absolute` siblings (z-stack) |
-//! | [`LayoutMod::padding`] | `padding` |
-//! | [`LayoutMod::width`]/[`LayoutMod::height`] | `width`/`height` |
-//! | [`LayoutMod::min_width`]/[`max_width`](LayoutMod::max_width) | `min-width`/`max-width` |
-//! | [`LayoutMod::aspect_ratio`] | `aspect-ratio` |
-//! | [`LayoutMod::align`] | `place-self` |
-//! | [`LayoutMod::fit`] | `object-fit` |
-//! | [`LayoutMod::background`] | `background-color` |
-//! | [`LayoutMod::border`] | `outline` (1-px) |
+//! | Color type, named constants, `rgb`/`rgba`/`hex` | [`color`] |
+//! | Sizes, rects, insets, axis/halign/valign | [`geom`] |
+//! | `SizeRule`/`MainAlign`/`CrossAlign`/`Fit`/`Track` | [`sizing`] |
+//! | `TextStyle` / `TextSpec` (font integration) | [`text`] |
+//! | Drawing primitives + image/text leaf paint | [`paint`] |
+//! | `Node` IR + measure/paint dispatch | [`node`] |
+//! | `Stack` / `row` / `column` builders + measure/paint | [`stack`] |
+//! | `Grid` / `Track` solver + areas + measure/paint | [`grid`] |
+//! | `Layers` builder + measure/paint | [`layers`] |
+//! | Modifier nodes + `LayoutMod` trait | [`modifiers`] |
+//! | `LabelStyle` / `LabelSegment` strip builders | [`label`] |
 
-use std::collections::HashMap;
+#![allow(clippy::too_many_arguments)]
+// Many `pub` items in this module exist for external callers gated by
+// the `_internal_api` feature (the layout_gallery example). When the
+// feature is off, those items appear unused — silence the noise.
+#![cfg_attr(not(feature = "_internal_api"), allow(dead_code, unused_imports))]
 
-use image::{Rgba, RgbaImage, imageops};
+use image::{Rgba, RgbaImage};
 
-use crate::font;
+pub mod color;
+pub mod geom;
+pub mod grid;
+pub mod label;
+pub mod layers;
+pub mod modifiers;
+pub mod node;
+pub mod paint;
+pub mod safety;
+pub mod sizing;
+pub mod stack;
+pub mod text;
 
-// ════════════════════════════════════════════════════════════════════════
-// Color
-// ════════════════════════════════════════════════════════════════════════
+// ── Public API re-exports ─────────────────────────────────────────────
 
-/// RGBA color (straight alpha, the `image` crate's storage convention).
-pub type Color = [u8; 4];
+pub use color::{BLACK, Color, TRANSPARENT, WHITE, hex, rgb, rgba};
+pub use geom::{Axis, HAlign, Insets, Rect, Size, VAlign};
+pub use grid::{Grid, GridSpan, grid};
+pub use label::{LabelSegment, LabelStyle};
+pub use layers::{Layers, layers};
+pub use modifiers::LayoutMod;
+pub use node::{DEFAULT_LINE_PADDING, Node, empty, fill, image, line, text};
+pub use paint::{draw_rect_border, fill_rect};
+pub use safety::{DEFAULT_BASE_EM, LayoutLimits};
+pub use sizing::{CrossAlign, Fit, MainAlign, SizeRule, Track};
+pub use stack::{Stack, column, row};
+pub use text::{TextSpec, TextStyle};
 
-pub const WHITE: Color = [255, 255, 255, 255];
-pub const BLACK: Color = [0, 0, 0, 255];
-pub const TRANSPARENT: Color = [0, 0, 0, 0];
+// ── Top-level render entry points ──────────────────────────────────────
 
-/// Build an opaque RGB color.
-pub const fn rgb(r: u8, g: u8, b: u8) -> Color {
-    [r, g, b, 255]
-}
+// ── RenderConfig ──────────────────────────────────────────────────────
 
-/// Build an RGBA color.
-pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Color {
-    [r, g, b, a]
-}
-
-/// Parse a CSS-style hex color: `#RGB`, `#RRGGBB`, or `#RRGGBBAA`. The
-/// leading `#` is optional. Panics at compile time (or runtime, if not
-/// in const context) on malformed input.
-pub const fn hex(s: &str) -> Color {
-    let bytes = s.as_bytes();
-    let len = bytes.len();
-    let start = if len > 0 && bytes[0] == b'#' { 1 } else { 0 };
-    let n = len - start;
-
-    if n == 3 {
-        let r = hex1(bytes[start]) * 17;
-        let g = hex1(bytes[start + 1]) * 17;
-        let b = hex1(bytes[start + 2]) * 17;
-        [r, g, b, 255]
-    } else if n == 6 {
-        [
-            hex2(bytes[start], bytes[start + 1]),
-            hex2(bytes[start + 2], bytes[start + 3]),
-            hex2(bytes[start + 4], bytes[start + 5]),
-            255,
-        ]
-    } else if n == 8 {
-        [
-            hex2(bytes[start], bytes[start + 1]),
-            hex2(bytes[start + 2], bytes[start + 3]),
-            hex2(bytes[start + 4], bytes[start + 5]),
-            hex2(bytes[start + 6], bytes[start + 7]),
-        ]
-    } else {
-        panic!("invalid hex color literal — expected #RGB, #RRGGBB, or #RRGGBBAA")
-    }
-}
-
-const fn hex2(hi: u8, lo: u8) -> u8 {
-    hex1(hi) * 16 + hex1(lo)
-}
-
-const fn hex1(b: u8) -> u8 {
-    match b {
-        b'0'..=b'9' => b - b'0',
-        b'a'..=b'f' => b - b'a' + 10,
-        b'A'..=b'F' => b - b'A' + 10,
-        _ => panic!("invalid hex digit"),
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Geometry
-// ════════════════════════════════════════════════════════════════════════
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct Size {
-    pub w: u32,
-    pub h: u32,
-}
-
-impl Size {
-    pub const fn new(w: u32, h: u32) -> Self {
-        Self { w, h }
-    }
-    pub const ZERO: Self = Self { w: 0, h: 0 };
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct Rect {
-    pub x: u32,
-    pub y: u32,
-    pub w: u32,
-    pub h: u32,
-}
-
-impl Rect {
-    pub const fn new(x: u32, y: u32, w: u32, h: u32) -> Self {
-        Self { x, y, w, h }
-    }
-    pub const fn size(&self) -> Size {
-        Size::new(self.w, self.h)
-    }
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct Insets {
-    pub left: u32,
-    pub top: u32,
-    pub right: u32,
-    pub bottom: u32,
-}
-
-impl Insets {
-    pub const fn all(v: u32) -> Self {
-        Self {
-            left: v,
-            top: v,
-            right: v,
-            bottom: v,
-        }
-    }
-    /// `Insets::xy(x, y)` — symmetric horizontal/vertical.
-    pub const fn xy(x: u32, y: u32) -> Self {
-        Self {
-            left: x,
-            top: y,
-            right: x,
-            bottom: y,
-        }
-    }
-    /// CSS shorthand order: top, right, bottom, left.
-    pub const fn each(top: u32, right: u32, bottom: u32, left: u32) -> Self {
-        Self {
-            top,
-            right,
-            bottom,
-            left,
-        }
-    }
-    pub const fn horizontal(&self) -> u32 {
-        self.left + self.right
-    }
-    pub const fn vertical(&self) -> u32 {
-        self.top + self.bottom
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Sizing & alignment enums
-// ════════════════════════════════════════════════════════════════════════
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Axis {
-    Horizontal,
-    Vertical,
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum HAlign {
-    Left,
-    #[default]
-    Center,
-    Right,
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum VAlign {
-    Top,
-    #[default]
-    Center,
-    Bottom,
-}
-
-/// Main-axis distribution within a [`Stack`]. Mirrors CSS `justify-content`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum MainAlign {
-    #[default]
-    Start,
-    Center,
-    End,
-    /// Equal gaps between children, none at edges.
-    SpaceBetween,
-    /// Half-gaps at edges, full gaps between children.
-    SpaceAround,
-    /// Equal gaps everywhere (between, before, after).
-    SpaceEvenly,
-}
-
-/// Cross-axis alignment of children within a [`Stack`]. Mirrors CSS
-/// `align-items`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum CrossAlign {
-    #[default]
-    Start,
-    Center,
-    End,
-    /// Stretch each child to fill the cross axis.
-    Stretch,
-}
-
-/// How an [`image`] leaf scales into its allotted rect — CSS `object-fit`.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum Fit {
-    /// Place at original size, clipped if larger than rect (CSS `none`).
-    #[default]
-    None,
-    /// Scale preserving aspect, fit entirely (letterbox).
-    Contain,
-    /// Scale preserving aspect, fill rect (crop overflow).
-    Cover,
-    /// Stretch to rect ignoring aspect.
-    Stretch,
-}
-
-/// Per-axis sizing rule for a node — analogous to CSS `width: auto/100%/<n>px`.
+/// Per-render configuration — separate from [`LayoutLimits`] (which is
+/// strictly safety) and from the tree itself.
 ///
-/// [`SizeRule::Grow`] is CSS `flex-grow: n` — among Grow children of a
-/// stack, remaining main-axis space is split proportionally to weight.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum SizeRule {
-    /// Hug content (CSS `auto`).
-    #[default]
-    Hug,
-    /// Fixed pixel size.
-    Fixed(u32),
-    /// Fill the parent constraint (CSS `100%`). Equivalent to `Grow(1)`
-    /// when used as the only flex rule, but inside a stack with mixed
-    /// `Grow`/`Fill` it consumes a single unit of weight.
-    Fill,
-    /// Weighted fill — CSS `flex-grow: n`.
-    Grow(u32),
-}
-
-impl SizeRule {
-    fn grow_weight(self) -> u32 {
-        match self {
-            SizeRule::Fill => 1,
-            SizeRule::Grow(w) => w,
-            _ => 0,
-        }
-    }
-}
-
-/// Grid track sizing — CSS `grid-template-columns` / `-rows`.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum Track {
-    /// Fixed pixel size.
-    Px(u32),
-    /// Fraction of remaining space (CSS `<n>fr`).
-    Fr(u32),
-    /// Hug the maximum content size in this track (CSS `auto` /
-    /// `min-content`).
-    Auto,
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Text
-// ════════════════════════════════════════════════════════════════════════
-
+/// `scale` is the CSS-`dppx` analogue: a uniform multiplier applied to
+/// every fixed-pixel quantity (Sized::Fixed, Insets, Track::Px, gap,
+/// pad, char_h) by walking the tree once via [`Node::scaled`]. `Fr`,
+/// `Percent`, and `Hug` are unchanged. `1.0` is no-op.
+///
+/// `base_em` is the `em(1.0)` baseline in pixels — used by the
+/// [`em`] free function to express padding/sizes relative to a
+/// design-baseline text height.
+///
+/// Default: `scale = 1.0`, `base_em = 16`, `bg = BLACK`,
+/// `limits = LayoutLimits::default()`.
 #[derive(Clone, Debug)]
-pub enum TextStyle {
-    /// One or more lines, each with its own color, sized so the longest
-    /// fits within the constraint width. [`font::render_lines_fitted`].
-    Lines(Vec<(String, Color)>),
-    /// Single line at a fixed character pixel-height. [`font::render_text_height`].
-    Fixed { text: String, fg: Color, char_h: u32 },
-    /// Word-wrapped text at a fixed character pixel-height.
-    /// [`font::render_text_wrapped`].
-    Wrapped {
-        text: String,
-        fg: Color,
-        char_h: u32,
-    },
-}
-
-#[derive(Clone, Debug)]
-pub struct TextSpec {
-    pub style: TextStyle,
-    /// Background color the glyph rasterizer alpha-blends against — set
-    /// to match the strip behind the text for clean edges.
+pub struct RenderConfig {
+    pub max_w: u32,
     pub bg: Color,
+    pub scale: f32,
+    pub base_em: u32,
+    pub limits: LayoutLimits,
 }
 
-impl TextSpec {
-    pub fn lines(lines: Vec<(impl Into<String>, Color)>, bg: Color) -> Self {
+impl RenderConfig {
+    pub fn new(max_w: u32) -> Self {
         Self {
-            style: TextStyle::Lines(lines.into_iter().map(|(s, c)| (s.into(), c)).collect()),
-            bg,
+            max_w,
+            bg: BLACK,
+            scale: 1.0,
+            base_em: DEFAULT_BASE_EM,
+            limits: LayoutLimits::default(),
         }
-    }
-    pub fn fixed(text: impl Into<String>, fg: Color, bg: Color, char_h: u32) -> Self {
-        Self {
-            style: TextStyle::Fixed {
-                text: text.into(),
-                fg,
-                char_h,
-            },
-            bg,
-        }
-    }
-    pub fn wrapped(text: impl Into<String>, fg: Color, bg: Color, char_h: u32) -> Self {
-        Self {
-            style: TextStyle::Wrapped {
-                text: text.into(),
-                fg,
-                char_h,
-            },
-            bg,
-        }
-    }
-
-    fn rasterize(&self, max_w: u32) -> (Vec<u8>, u32, u32) {
-        if max_w == 0 {
-            return (vec![], 0, 0);
-        }
-        match &self.style {
-            TextStyle::Lines(lines) => {
-                let refs: Vec<(&str, Color)> =
-                    lines.iter().map(|(s, c)| (s.as_str(), *c)).collect();
-                font::render_lines_fitted(&refs, self.bg, max_w)
-            }
-            TextStyle::Fixed { text, fg, char_h } => {
-                font::render_text_height(text, *fg, self.bg, *char_h)
-            }
-            TextStyle::Wrapped { text, fg, char_h } => {
-                font::render_text_wrapped(text, *fg, self.bg, *char_h, max_w)
-            }
-        }
-    }
-
-    fn natural(&self, max_w: u32) -> Size {
-        if max_w == 0 {
-            return Size::ZERO;
-        }
-        let (w, h) = match &self.style {
-            TextStyle::Lines(lines) => {
-                let refs: Vec<(&str, Color)> =
-                    lines.iter().map(|(s, c)| (s.as_str(), *c)).collect();
-                font::measure_lines_fitted(&refs, max_w)
-            }
-            TextStyle::Fixed { text, char_h, .. } => font::measure_text_height(text, *char_h),
-            TextStyle::Wrapped { text, char_h, .. } => {
-                font::measure_text_wrapped(text, *char_h, max_w)
-            }
-        };
-        Size::new(w, h)
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Node IR
-// ════════════════════════════════════════════════════════════════════════
-
-/// The retained layout tree.
-///
-/// Construct via the free functions ([`image`], [`text`], [`line`],
-/// [`fill`], [`empty`]) and builders ([`row`], [`column`], [`grid`],
-/// [`layers`]); chain modifiers from the [`LayoutMod`] trait.
-#[derive(Clone, Debug)]
-pub enum Node {
-    // ── Leaves ────────────────────────────────────────────────────────
-    Empty,
-    Fill(Color),
-    Image(RgbaImage),
-    Text(TextSpec),
-
-    // ── Containers ────────────────────────────────────────────────────
-    Stack {
-        axis: Axis,
-        gap: u32,
-        justify: MainAlign,
-        align_items: CrossAlign,
-        children: Vec<Node>,
-    },
-    Grid {
-        cols: Vec<Track>,
-        rows: Vec<Track>,
-        gap: (u32, u32),
-        pad: u32,
-        cells: Vec<(GridSpan, Node)>,
-    },
-    Layers(Vec<Node>),
-
-    // ── Modifiers ─────────────────────────────────────────────────────
-    Padded {
-        insets: Insets,
-        child: Box<Node>,
-    },
-    Sized {
-        w: SizeRule,
-        h: SizeRule,
-        child: Box<Node>,
-    },
-    Constrain {
-        min_w: Option<u32>,
-        max_w: Option<u32>,
-        min_h: Option<u32>,
-        max_h: Option<u32>,
-        child: Box<Node>,
-    },
-    Aspect {
-        num: u32,
-        den: u32,
-        child: Box<Node>,
-    },
-    Align {
-        h: HAlign,
-        v: VAlign,
-        child: Box<Node>,
-    },
-    Fit {
-        mode: Fit,
-        child: Box<Node>,
-    },
-    Background {
-        color: Color,
-        child: Box<Node>,
-    },
-    Border {
-        color: Color,
-        child: Box<Node>,
-    },
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct GridSpan {
-    pub col: u32,
-    pub row: u32,
-    pub colspan: u32,
-    pub rowspan: u32,
-}
-
-impl GridSpan {
-    pub const fn cell(col: u32, row: u32) -> Self {
-        Self {
-            col,
-            row,
-            colspan: 1,
-            rowspan: 1,
-        }
-    }
-    pub const fn span(col: u32, row: u32, colspan: u32, rowspan: u32) -> Self {
-        Self {
-            col,
-            row,
-            colspan,
-            rowspan,
-        }
-    }
-    fn cs(&self) -> u32 {
-        self.colspan.max(1)
-    }
-    fn rs(&self) -> u32 {
-        self.rowspan.max(1)
-    }
-}
-
-// ── Implicit conversions ───────────────────────────────────────────────
-
-impl From<&str> for Node {
-    /// Default: white text on black (pre-blended). For non-default
-    /// background, use [`text`] / [`line`] explicitly.
-    fn from(s: &str) -> Node {
-        Node::Text(TextSpec::lines(vec![(s.to_string(), WHITE)], BLACK))
-    }
-}
-impl From<String> for Node {
-    fn from(s: String) -> Node {
-        Node::Text(TextSpec::lines(vec![(s, WHITE)], BLACK))
-    }
-}
-impl From<RgbaImage> for Node {
-    fn from(img: RgbaImage) -> Node {
-        Node::Image(img)
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Free-function constructors
-// ════════════════════════════════════════════════════════════════════════
-
-pub fn empty() -> Node {
-    Node::Empty
-}
-pub fn fill(c: Color) -> Node {
-    Node::Fill(c)
-}
-pub fn image(img: RgbaImage) -> Node {
-    Node::Image(img)
-}
-pub fn text(spec: TextSpec) -> Node {
-    Node::Text(spec)
-}
-/// Single-line text on a transparent background, sized to fit the
-/// constraint width.
-pub fn line(s: impl Into<String>, fg: Color) -> Node {
-    Node::Text(TextSpec::lines(vec![(s.into(), fg)], TRANSPARENT))
-}
-
-pub fn row() -> Stack {
-    Stack::new(Axis::Horizontal)
-}
-pub fn column() -> Stack {
-    Stack::new(Axis::Vertical)
-}
-pub fn grid() -> Grid {
-    Grid::new()
-}
-pub fn layers() -> Layers {
-    Layers::new()
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Stack builder
-// ════════════════════════════════════════════════════════════════════════
-
-#[derive(Clone, Debug)]
-pub struct Stack {
-    axis: Axis,
-    gap: u32,
-    justify: MainAlign,
-    align_items: CrossAlign,
-    children: Vec<Node>,
-}
-
-impl Stack {
-    pub fn new(axis: Axis) -> Self {
-        Self {
-            axis,
-            gap: 0,
-            justify: MainAlign::Start,
-            align_items: CrossAlign::Start,
-            children: Vec::new(),
-        }
-    }
-
-    pub fn gap(mut self, g: u32) -> Self {
-        self.gap = g;
-        self
-    }
-    pub fn justify(mut self, j: MainAlign) -> Self {
-        self.justify = j;
-        self
-    }
-    pub fn align_items(mut self, a: CrossAlign) -> Self {
-        self.align_items = a;
-        self
-    }
-    pub fn child(mut self, c: impl Into<Node>) -> Self {
-        self.children.push(c.into());
-        self
-    }
-    pub fn children<I, N>(mut self, items: I) -> Self
-    where
-        I: IntoIterator<Item = N>,
-        N: Into<Node>,
-    {
-        self.children.extend(items.into_iter().map(Into::into));
-        self
-    }
-}
-
-impl From<Stack> for Node {
-    fn from(s: Stack) -> Node {
-        Node::Stack {
-            axis: s.axis,
-            gap: s.gap,
-            justify: s.justify,
-            align_items: s.align_items,
-            children: s.children,
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Grid builder
-// ════════════════════════════════════════════════════════════════════════
-
-#[derive(Clone, Debug, Default)]
-pub struct Grid {
-    cols: Vec<Track>,
-    rows: Vec<Track>,
-    gap: (u32, u32),
-    pad: u32,
-    cells: Vec<(GridSpan, Node)>,
-    areas: HashMap<String, GridSpan>,
-}
-
-impl Grid {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn columns(mut self, tracks: impl IntoIterator<Item = Track>) -> Self {
-        self.cols = tracks.into_iter().collect();
-        self
-    }
-    pub fn rows(mut self, tracks: impl IntoIterator<Item = Track>) -> Self {
-        self.rows = tracks.into_iter().collect();
-        self
-    }
-    /// Alias for [`Grid::columns`] — reads better paired with [`row_heights`].
-    pub fn col_widths(self, tracks: impl IntoIterator<Item = Track>) -> Self {
-        self.columns(tracks)
-    }
-    /// Alias for [`Grid::rows`].
-    pub fn row_heights(self, tracks: impl IntoIterator<Item = Track>) -> Self {
-        self.rows(tracks)
-    }
-    /// Equal-weight fr columns: shorthand for `vec![Track::Fr(1); n]`.
-    pub fn cols(mut self, n: u32) -> Self {
-        self.cols = (0..n).map(|_| Track::Fr(1)).collect();
-        self
-    }
-    /// Equal-weight fr rows.
-    pub fn equal_rows(mut self, n: u32) -> Self {
-        self.rows = (0..n).map(|_| Track::Fr(1)).collect();
-        self
-    }
-
-    pub fn gap(mut self, g: u32) -> Self {
-        self.gap = (g, g);
-        self
-    }
-    pub fn gap_xy(mut self, x: u32, y: u32) -> Self {
-        self.gap = (x, y);
-        self
-    }
-    pub fn padding(mut self, p: u32) -> Self {
-        self.pad = p;
-        self
-    }
-
-    pub fn cell(mut self, col: u32, row: u32, n: impl Into<Node>) -> Self {
-        self.cells.push((GridSpan::cell(col, row), n.into()));
-        self
-    }
-    pub fn span(
-        mut self,
-        col: u32,
-        row: u32,
-        colspan: u32,
-        rowspan: u32,
-        n: impl Into<Node>,
-    ) -> Self {
-        self.cells
-            .push((GridSpan::span(col, row, colspan, rowspan), n.into()));
-        self
-    }
-
-    /// Define named areas by an ASCII-art template — like CSS
-    /// `grid-template-areas`. Each row is a string of whitespace-separated
-    /// tokens; `.` is empty. All rows must have the same column count.
-    /// Repeated tokens form a single area whose bounding box is computed.
-    ///
-    /// If `cols`/`rows` haven't been set explicitly, this also infers
-    /// equal-weight Fr tracks from the template's dimensions.
-    pub fn areas(mut self, rows: &[&str]) -> Self {
-        if rows.is_empty() {
-            return self;
-        }
-        let row_tokens: Vec<Vec<&str>> = rows
-            .iter()
-            .map(|r| r.split_whitespace().collect())
-            .collect();
-        let cols_count = row_tokens[0].len() as u32;
-        for (i, r) in row_tokens.iter().enumerate() {
-            assert_eq!(
-                r.len() as u32,
-                cols_count,
-                "Grid::areas row {i} has {} cols, expected {cols_count}",
-                r.len()
-            );
-        }
-        let rows_count = rows.len() as u32;
-
-        // name → (col_min, row_min, col_max, row_max)
-        let mut bbox: HashMap<String, (u32, u32, u32, u32)> = HashMap::new();
-        for (r, line) in row_tokens.iter().enumerate() {
-            for (c, tok) in line.iter().enumerate() {
-                if *tok == "." {
-                    continue;
-                }
-                let key = (*tok).to_string();
-                let entry = bbox
-                    .entry(key)
-                    .or_insert((c as u32, r as u32, c as u32, r as u32));
-                entry.0 = entry.0.min(c as u32);
-                entry.1 = entry.1.min(r as u32);
-                entry.2 = entry.2.max(c as u32);
-                entry.3 = entry.3.max(r as u32);
-            }
-        }
-        self.areas = bbox
-            .into_iter()
-            .map(|(name, (c0, r0, c1, r1))| {
-                (
-                    name,
-                    GridSpan::span(c0, r0, c1 - c0 + 1, r1 - r0 + 1),
-                )
-            })
-            .collect();
-
-        if self.cols.is_empty() {
-            self.cols = (0..cols_count).map(|_| Track::Fr(1)).collect();
-        }
-        if self.rows.is_empty() {
-            self.rows = (0..rows_count).map(|_| Track::Fr(1)).collect();
-        }
-        self
-    }
-
-    /// Place a child in a named area defined by [`Grid::areas`].
-    /// Panics if `name` is unknown.
-    pub fn place(mut self, name: &str, n: impl Into<Node>) -> Self {
-        let span = *self
-            .areas
-            .get(name)
-            .unwrap_or_else(|| panic!("Grid::place: no area named {name:?}"));
-        self.cells.push((span, n.into()));
-        self
-    }
-}
-
-impl From<Grid> for Node {
-    fn from(g: Grid) -> Node {
-        Node::Grid {
-            cols: g.cols,
-            rows: g.rows,
-            gap: g.gap,
-            pad: g.pad,
-            cells: g.cells,
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Layers builder
-// ════════════════════════════════════════════════════════════════════════
-
-#[derive(Clone, Debug, Default)]
-pub struct Layers {
-    children: Vec<Node>,
-}
-
-impl Layers {
-    pub fn new() -> Self {
-        Self::default()
-    }
-    pub fn child(mut self, c: impl Into<Node>) -> Self {
-        self.children.push(c.into());
-        self
-    }
-    pub fn children<I, N>(mut self, items: I) -> Self
-    where
-        I: IntoIterator<Item = N>,
-        N: Into<Node>,
-    {
-        self.children.extend(items.into_iter().map(Into::into));
-        self
-    }
-}
-
-impl From<Layers> for Node {
-    fn from(l: Layers) -> Node {
-        Node::Layers(l.children)
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// LayoutMod — fluent modifiers on anything that converts to Node
-// ════════════════════════════════════════════════════════════════════════
-
-/// Modifier methods on any layout node or builder. Auto-imported via
-/// `use zensim_regress::layout::*;`.
-pub trait LayoutMod: Sized {
-    fn into_node(self) -> Node;
-
-    // ── Padding (CSS `padding`) ────────────────────────────────────────
-    fn padding(self, v: u32) -> Node {
-        wrap_padded(self.into_node(), Insets::all(v))
-    }
-    fn padding_xy(self, x: u32, y: u32) -> Node {
-        wrap_padded(self.into_node(), Insets::xy(x, y))
-    }
-    /// CSS shorthand order: top, right, bottom, left.
-    fn padding_each(self, t: u32, r: u32, b: u32, l: u32) -> Node {
-        wrap_padded(self.into_node(), Insets::each(t, r, b, l))
-    }
-
-    // ── Sizing (CSS `width`, `height`) ────────────────────────────────
-    fn width(self, r: SizeRule) -> Node {
-        wrap_sized(self.into_node(), r, SizeRule::Hug)
-    }
-    fn height(self, r: SizeRule) -> Node {
-        wrap_sized(self.into_node(), SizeRule::Hug, r)
-    }
-    /// Fixed `(w, h)`.
-    fn size(self, w: u32, h: u32) -> Node {
-        wrap_sized(self.into_node(), SizeRule::Fixed(w), SizeRule::Fixed(h))
-    }
-    fn fill_width(self) -> Node {
-        wrap_sized(self.into_node(), SizeRule::Fill, SizeRule::Hug)
-    }
-    fn fill_height(self) -> Node {
-        wrap_sized(self.into_node(), SizeRule::Hug, SizeRule::Fill)
-    }
-    fn fill(self) -> Node {
-        wrap_sized(self.into_node(), SizeRule::Fill, SizeRule::Fill)
-    }
-    /// Weighted main-axis grow (CSS `flex-grow`). Only meaningful inside
-    /// a stack with other Grow/Fill children.
-    fn grow(self, weight: u32) -> Node {
-        wrap_sized(self.into_node(), SizeRule::Grow(weight), SizeRule::Hug)
-    }
-
-    // ── Min/Max constraints (CSS `min-width` etc.) ────────────────────
-    fn min_width(self, n: u32) -> Node {
-        wrap_constrain(self.into_node(), Some(n), None, None, None)
-    }
-    fn max_width(self, n: u32) -> Node {
-        wrap_constrain(self.into_node(), None, Some(n), None, None)
-    }
-    fn min_height(self, n: u32) -> Node {
-        wrap_constrain(self.into_node(), None, None, Some(n), None)
-    }
-    fn max_height(self, n: u32) -> Node {
-        wrap_constrain(self.into_node(), None, None, None, Some(n))
-    }
-
-    /// CSS `aspect-ratio: <num> / <den>`.
-    fn aspect_ratio(self, num: u32, den: u32) -> Node {
-        Node::Aspect {
-            num: num.max(1),
-            den: den.max(1),
-            child: Box::new(self.into_node()),
-        }
-    }
-
-    // ── Alignment (CSS `place-self`) ──────────────────────────────────
-    fn align(self, h: HAlign, v: VAlign) -> Node {
-        Node::Align {
-            h,
-            v,
-            child: Box::new(self.into_node()),
-        }
-    }
-    fn center(self) -> Node {
-        self.align(HAlign::Center, VAlign::Center)
-    }
-    fn align_h(self, h: HAlign) -> Node {
-        self.align(h, VAlign::Top)
-    }
-    fn align_v(self, v: VAlign) -> Node {
-        self.align(HAlign::Left, v)
-    }
-
-    // ── Image fit (CSS `object-fit`) ──────────────────────────────────
-    fn fit(self, mode: Fit) -> Node {
-        Node::Fit {
-            mode,
-            child: Box::new(self.into_node()),
-        }
-    }
-    fn fit_contain(self) -> Node {
-        self.fit(Fit::Contain)
-    }
-    fn fit_cover(self) -> Node {
-        self.fit(Fit::Cover)
-    }
-    fn fit_stretch(self) -> Node {
-        self.fit(Fit::Stretch)
-    }
-
-    // ── Painting ──────────────────────────────────────────────────────
-    fn background(self, c: Color) -> Node {
-        Node::Background {
-            color: c,
-            child: Box::new(self.into_node()),
-        }
-    }
-    fn border(self, c: Color) -> Node {
-        Node::Border {
-            color: c,
-            child: Box::new(self.into_node()),
-        }
-    }
-
-    // ── Label shortcuts ───────────────────────────────────────────────
-    fn label(self, s: impl Into<String>) -> Node {
-        self.label_styled(s, &LabelStyle::default())
-    }
-    fn label_styled(self, s: impl Into<String>, style: &LabelStyle) -> Node {
-        column().gap(0).child(style.strip(s)).child(self.into_node()).into()
-    }
-    fn label_segments(self, segments: Vec<LabelSegment>, style: &LabelStyle) -> Node {
-        column()
-            .gap(0)
-            .child(style.segmented_strip(segments))
-            .child(self.into_node())
-            .into()
-    }
-
-    /// Render this tree into an [`RgbaImage`] of width `max_w`. Convenience
-    /// for `render(&node, max_w)` when you have a builder in hand.
-    fn render(self, max_w: u32) -> RgbaImage {
-        render(&self.into_node(), max_w)
-    }
-}
-
-fn wrap_padded(child: Node, insets: Insets) -> Node {
-    Node::Padded {
-        insets,
-        child: Box::new(child),
-    }
-}
-fn wrap_sized(child: Node, w: SizeRule, h: SizeRule) -> Node {
-    Node::Sized {
-        w,
-        h,
-        child: Box::new(child),
-    }
-}
-fn wrap_constrain(
-    child: Node,
-    min_w: Option<u32>,
-    max_w: Option<u32>,
-    min_h: Option<u32>,
-    max_h: Option<u32>,
-) -> Node {
-    Node::Constrain {
-        min_w,
-        max_w,
-        min_h,
-        max_h,
-        child: Box::new(child),
-    }
-}
-
-impl LayoutMod for Node {
-    fn into_node(self) -> Node {
-        self
-    }
-}
-impl LayoutMod for Stack {
-    fn into_node(self) -> Node {
-        self.into()
-    }
-}
-impl LayoutMod for Grid {
-    fn into_node(self) -> Node {
-        self.into()
-    }
-}
-impl LayoutMod for Layers {
-    fn into_node(self) -> Node {
-        self.into()
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Measurement
-// ════════════════════════════════════════════════════════════════════════
-
-impl Node {
-    /// Measure this node given the maximum available `(w, h)`. Returns
-    /// the size the node wants, always clamped to `max`.
-    pub fn measure(&self, max: Size) -> Size {
-        let raw = self.measure_raw(max);
-        Size::new(raw.w.min(max.w), raw.h.min(max.h))
-    }
-
-    fn measure_raw(&self, max: Size) -> Size {
-        match self {
-            Node::Empty => Size::ZERO,
-            Node::Fill(_) => Size::ZERO,
-            Node::Image(img) => Size::new(img.width(), img.height()),
-            Node::Text(spec) => spec.natural(max.w),
-
-            Node::Stack {
-                axis,
-                gap,
-                children,
-                ..
-            } => measure_stack(*axis, *gap, children, max),
-
-            Node::Grid {
-                cols,
-                rows,
-                gap,
-                pad,
-                cells,
-            } => measure_grid(cols, rows, *gap, *pad, cells, max),
-
-            Node::Layers(children) => {
-                let mut out = Size::ZERO;
-                for c in children {
-                    let s = c.measure(max);
-                    out.w = out.w.max(s.w);
-                    out.h = out.h.max(s.h);
-                }
-                out
-            }
-
-            Node::Padded { insets, child } => {
-                let inner_max = Size::new(
-                    max.w.saturating_sub(insets.horizontal()),
-                    max.h.saturating_sub(insets.vertical()),
-                );
-                let inner = child.measure(inner_max);
-                Size::new(inner.w + insets.horizontal(), inner.h + insets.vertical())
-            }
-
-            Node::Sized { w, h, child } => {
-                let child_size = child.measure(max);
-                let out_w = match w {
-                    SizeRule::Hug => child_size.w,
-                    SizeRule::Fill | SizeRule::Grow(_) => max.w,
-                    SizeRule::Fixed(v) => *v,
-                };
-                let out_h = match h {
-                    SizeRule::Hug => child_size.h,
-                    SizeRule::Fill | SizeRule::Grow(_) => max.h,
-                    SizeRule::Fixed(v) => *v,
-                };
-                Size::new(out_w, out_h)
-            }
-
-            Node::Constrain {
-                min_w,
-                max_w,
-                min_h,
-                max_h,
-                child,
-            } => {
-                let child_max = Size::new(
-                    max_w.map_or(max.w, |v| v.min(max.w)),
-                    max_h.map_or(max.h, |v| v.min(max.h)),
-                );
-                let s = child.measure(child_max);
-                Size::new(
-                    s.w.max(min_w.unwrap_or(0))
-                        .min(max_w.unwrap_or(u32::MAX))
-                        .min(max.w),
-                    s.h.max(min_h.unwrap_or(0))
-                        .min(max_h.unwrap_or(u32::MAX))
-                        .min(max.h),
-                )
-            }
-
-            Node::Aspect { num, den, child } => measure_aspect(*num, *den, child, max),
-
-            Node::Align { child, .. } => child.measure(max),
-            Node::Fit { child, .. } => child.measure(max),
-            Node::Background { child, .. } => child.measure(max),
-            Node::Border { child, .. } => child.measure(max),
-        }
-    }
-}
-
-fn measure_stack(axis: Axis, gap: u32, children: &[Node], max: Size) -> Size {
-    if children.is_empty() {
-        return Size::ZERO;
-    }
-    let n = children.len() as u32;
-    let total_gap = gap.saturating_mul(n.saturating_sub(1));
-
-    let (main_max, cross_max) = match axis {
-        Axis::Horizontal => (max.w.saturating_sub(total_gap), max.h),
-        Axis::Vertical => (max.h.saturating_sub(total_gap), max.w),
-    };
-    let child_max = match axis {
-        Axis::Horizontal => Size::new(main_max, cross_max),
-        Axis::Vertical => Size::new(cross_max, main_max),
-    };
-
-    let mut main = 0u32;
-    let mut cross = 0u32;
-    for c in children {
-        let s = c.measure(child_max);
-        let (m, x) = match axis {
-            Axis::Horizontal => (s.w, s.h),
-            Axis::Vertical => (s.h, s.w),
-        };
-        main = main.saturating_add(m);
-        cross = cross.max(x);
-    }
-    main = main.saturating_add(total_gap);
-    match axis {
-        Axis::Horizontal => Size::new(main, cross),
-        Axis::Vertical => Size::new(cross, main),
-    }
-}
-
-fn measure_grid(
-    cols: &[Track],
-    rows: &[Track],
-    gap: (u32, u32),
-    pad: u32,
-    cells: &[(GridSpan, Node)],
-    max: Size,
-) -> Size {
-    if cols.is_empty() || rows.is_empty() {
-        return Size::ZERO;
-    }
-    let inner_w = max
-        .w
-        .saturating_sub(pad * 2)
-        .saturating_sub(gap.0.saturating_mul(cols.len().saturating_sub(1) as u32));
-    let inner_h = max
-        .h
-        .saturating_sub(pad * 2)
-        .saturating_sub(gap.1.saturating_mul(rows.len().saturating_sub(1) as u32));
-    let col_widths = solve_tracks(cols, inner_w, |c| {
-        max_natural_in_track(cells, c, true, gap, max)
-    });
-    let row_heights = solve_tracks(rows, inner_h, |r| {
-        max_natural_in_track(cells, r, false, gap, max)
-    });
-    let total_w =
-        pad * 2 + col_widths.iter().sum::<u32>() + gap.0.saturating_mul(cols.len() as u32 - 1);
-    let total_h =
-        pad * 2 + row_heights.iter().sum::<u32>() + gap.1.saturating_mul(rows.len() as u32 - 1);
-    Size::new(total_w.min(max.w), total_h.min(max.h))
-}
-
-/// For Auto-track sizing: find the max natural size of any cell whose
-/// span includes track index `idx` along the given axis, divided by the
-/// span length so a 2-col-spanning child contributes half its width to
-/// each spanned column.
-fn max_natural_in_track(
-    cells: &[(GridSpan, Node)],
-    idx: u32,
-    is_col: bool,
-    gap: (u32, u32),
-    max: Size,
-) -> u32 {
-    let mut out = 0u32;
-    for (span, child) in cells {
-        let (start, len) = if is_col {
-            (span.col, span.cs())
-        } else {
-            (span.row, span.rs())
-        };
-        if idx < start || idx >= start + len {
-            continue;
-        }
-        // Measure with a generous constraint — auto tracks should hug.
-        let s = child.measure(max);
-        let dim = if is_col { s.w } else { s.h };
-        // Subtract internal gaps when distributing across span.
-        let internal_gap = if is_col { gap.0 } else { gap.1 };
-        let spread = dim
-            .saturating_sub(internal_gap.saturating_mul(len.saturating_sub(1)))
-            .div_ceil(len.max(1));
-        out = out.max(spread);
-    }
-    out
-}
-
-/// Solve track sizes given total available space along that axis.
-///
-/// 1. Px tracks consume their fixed size.
-/// 2. Auto tracks consume their content size (via `auto_size` callback).
-/// 3. Remaining space is distributed among Fr tracks proportionally to
-///    their fr weight.
-#[allow(clippy::manual_checked_ops)]
-fn solve_tracks(tracks: &[Track], available: u32, auto_size: impl Fn(u32) -> u32) -> Vec<u32> {
-    let mut sizes = vec![0u32; tracks.len()];
-    let mut consumed = 0u32;
-    let mut total_fr = 0u32;
-
-    for (i, t) in tracks.iter().enumerate() {
-        match t {
-            Track::Px(v) => {
-                sizes[i] = *v;
-                consumed = consumed.saturating_add(*v);
-            }
-            Track::Auto => {
-                let v = auto_size(i as u32);
-                sizes[i] = v;
-                consumed = consumed.saturating_add(v);
-            }
-            Track::Fr(w) => {
-                total_fr = total_fr.saturating_add(*w);
-            }
-        }
-    }
-    if total_fr > 0 {
-        let remainder = available.saturating_sub(consumed);
-        // First (n-1) Fr tracks get floor share; last Fr track gets the
-        // remainder so we don't lose pixels to integer division.
-        let mut allotted = 0u32;
-        let mut last_fr_idx: Option<usize> = None;
-        for (i, t) in tracks.iter().enumerate() {
-            if let Track::Fr(w) = t {
-                let share = remainder * *w / total_fr;
-                sizes[i] = share;
-                allotted = allotted.saturating_add(share);
-                last_fr_idx = Some(i);
-            }
-        }
-        if let Some(i) = last_fr_idx {
-            sizes[i] = sizes[i].saturating_add(remainder.saturating_sub(allotted));
-        }
-    }
-    sizes
-}
-
-fn measure_aspect(num: u32, den: u32, child: &Node, max: Size) -> Size {
-    let s = child.measure(max);
-    let cw = s.w.max(1);
-    let ch = s.h.max(1);
-    let h_from_w = cw * den / num;
-    let w_from_h = ch * num / den;
-    if h_from_w <= max.h && cw <= max.w && h_from_w >= ch {
-        Size::new(cw, h_from_w)
-    } else if w_from_h <= max.w && ch <= max.h {
-        Size::new(w_from_h, ch)
-    } else {
-        // Both candidates exceed; scale to fit max while preserving ratio.
-        let h_from_max_w = max.w * den / num;
-        if h_from_max_w <= max.h {
-            Size::new(max.w, h_from_max_w)
-        } else {
-            Size::new(max.h * num / den, max.h)
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Rendering
-// ════════════════════════════════════════════════════════════════════════
-
-/// Render `tree` against `max_w`. The canvas height is derived from the
-/// tree's measured height. The default canvas background is opaque black.
-pub fn render(tree: &Node, max_w: u32) -> RgbaImage {
-    render_with(tree, max_w, BLACK)
-}
-
-/// As [`render`], with a custom default canvas background.
-pub fn render_with(tree: &Node, max_w: u32, bg: Color) -> RgbaImage {
-    let root_max = Size::new(max_w, u32::MAX / 2);
-    let s = tree.measure(root_max);
-    let mut canvas = RgbaImage::from_pixel(s.w.max(1), s.h.max(1), Rgba(bg));
-    tree.paint(Rect::new(0, 0, s.w, s.h), &mut canvas);
-    canvas
-}
-
-/// Render the tree into an existing canvas at `rect`.
-pub fn render_into(tree: &Node, rect: Rect, canvas: &mut RgbaImage) {
-    tree.paint(rect, canvas);
-}
-
-impl Node {
-    fn paint(&self, rect: Rect, canvas: &mut RgbaImage) {
-        if rect.w == 0 || rect.h == 0 {
-            return;
-        }
-        match self {
-            Node::Empty => {}
-            Node::Fill(c) => fill_rect(canvas, rect, *c),
-            Node::Image(img) => render_image(img, Fit::None, rect, canvas),
-            Node::Text(spec) => render_text(spec, rect, canvas),
-
-            Node::Stack {
-                axis,
-                gap,
-                justify,
-                align_items,
-                children,
-            } => render_stack(*axis, *gap, *justify, *align_items, children, rect, canvas),
-
-            Node::Grid {
-                cols,
-                rows,
-                gap,
-                pad,
-                cells,
-            } => render_grid(cols, rows, *gap, *pad, cells, rect, canvas),
-
-            Node::Layers(children) => {
-                for c in children {
-                    c.paint(rect, canvas);
-                }
-            }
-
-            Node::Padded { insets, child } => {
-                let inner = Rect::new(
-                    rect.x.saturating_add(insets.left),
-                    rect.y.saturating_add(insets.top),
-                    rect.w.saturating_sub(insets.horizontal()),
-                    rect.h.saturating_sub(insets.vertical()),
-                );
-                child.paint(inner, canvas);
-            }
-            Node::Sized { child, .. } => child.paint(rect, canvas),
-            Node::Constrain { child, .. } => child.paint(rect, canvas),
-            Node::Aspect { child, .. } => child.paint(rect, canvas),
-            Node::Align { h, v, child } => {
-                let child_size = child.measure(rect.size());
-                let x_off = match h {
-                    HAlign::Left => 0,
-                    HAlign::Center => rect.w.saturating_sub(child_size.w) / 2,
-                    HAlign::Right => rect.w.saturating_sub(child_size.w),
-                };
-                let y_off = match v {
-                    VAlign::Top => 0,
-                    VAlign::Center => rect.h.saturating_sub(child_size.h) / 2,
-                    VAlign::Bottom => rect.h.saturating_sub(child_size.h),
-                };
-                let inner = Rect::new(
-                    rect.x.saturating_add(x_off),
-                    rect.y.saturating_add(y_off),
-                    child_size.w.min(rect.w),
-                    child_size.h.min(rect.h),
-                );
-                child.paint(inner, canvas);
-            }
-            Node::Fit { mode, child } => {
-                if let Node::Image(img) = child.as_ref() {
-                    render_image(img, *mode, rect, canvas);
-                } else {
-                    child.paint(rect, canvas);
-                }
-            }
-            Node::Background { color, child } => {
-                fill_rect(canvas, rect, *color);
-                child.paint(rect, canvas);
-            }
-            Node::Border { color, child } => {
-                child.paint(rect, canvas);
-                draw_rect_border(canvas, rect, *color);
-            }
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments, clippy::manual_checked_ops)]
-fn render_stack(
-    axis: Axis,
-    gap: u32,
-    justify: MainAlign,
-    align_items: CrossAlign,
-    children: &[Node],
-    rect: Rect,
-    canvas: &mut RgbaImage,
-) {
-    if children.is_empty() {
-        return;
-    }
-    let n = children.len() as u32;
-    let total_gap = gap.saturating_mul(n.saturating_sub(1));
-    let (main_avail, cross_avail) = match axis {
-        Axis::Horizontal => (rect.w.saturating_sub(total_gap), rect.h),
-        Axis::Vertical => (rect.h.saturating_sub(total_gap), rect.w),
-    };
-    let child_max = match axis {
-        Axis::Horizontal => Size::new(main_avail, cross_avail),
-        Axis::Vertical => Size::new(cross_avail, main_avail),
-    };
-
-    // Gather grow weights (Fill + Grow) and natural main sizes.
-    let mut weights: Vec<u32> = vec![0; children.len()];
-    let mut measured: Vec<Size> = Vec::with_capacity(children.len());
-    let mut used_main = 0u32;
-    let mut total_weight = 0u32;
-    for (i, c) in children.iter().enumerate() {
-        let s = c.measure(child_max);
-        let w = main_grow_weight(c, axis);
-        weights[i] = w;
-        total_weight = total_weight.saturating_add(w);
-        let main_dim = match axis {
-            Axis::Horizontal => s.w,
-            Axis::Vertical => s.h,
-        };
-        if w == 0 {
-            used_main = used_main.saturating_add(main_dim);
-        }
-        measured.push(s);
-    }
-
-    let remainder = main_avail.saturating_sub(used_main);
-
-    // Compute per-child main size.
-    let mut main_sizes: Vec<u32> = vec![0; children.len()];
-    let mut allotted = 0u32;
-    let mut last_flex_idx: Option<usize> = None;
-    for i in 0..children.len() {
-        if weights[i] > 0 {
-            let share = if total_weight > 0 {
-                remainder * weights[i] / total_weight
-            } else {
-                0
-            };
-            main_sizes[i] = share;
-            allotted = allotted.saturating_add(share);
-            last_flex_idx = Some(i);
-        } else {
-            main_sizes[i] = match axis {
-                Axis::Horizontal => measured[i].w,
-                Axis::Vertical => measured[i].h,
-            };
-        }
-    }
-    if let Some(i) = last_flex_idx {
-        main_sizes[i] = main_sizes[i].saturating_add(remainder.saturating_sub(allotted));
-    }
-
-    let total_children_main: u32 = main_sizes.iter().sum();
-    let leftover = main_avail.saturating_sub(total_children_main);
-
-    // Compute starting offset and inter-child spacing per justify.
-    let (mut cursor, lead_pad, extra_gap) = match justify {
-        MainAlign::Start => (0u32, 0u32, 0u32),
-        MainAlign::Center => (leftover / 2, 0, 0),
-        MainAlign::End => (leftover, 0, 0),
-        MainAlign::SpaceBetween if n > 1 => (0, 0, leftover / (n - 1)),
-        MainAlign::SpaceBetween => (0, 0, 0),
-        MainAlign::SpaceAround => {
-            let unit = if n > 0 { leftover / n } else { 0 };
-            (unit / 2, 0, unit)
-        }
-        MainAlign::SpaceEvenly => {
-            let unit = leftover / (n + 1);
-            (unit, 0, unit)
-        }
-    };
-    cursor = cursor.saturating_add(lead_pad);
-    cursor = cursor.saturating_add(match axis {
-        Axis::Horizontal => rect.x,
-        Axis::Vertical => rect.y,
-    });
-
-    for (i, child) in children.iter().enumerate() {
-        let m_size = main_sizes[i];
-        let cross_natural = match axis {
-            Axis::Horizontal => measured[i].h,
-            Axis::Vertical => measured[i].w,
-        };
-        let cross_size = match align_items {
-            CrossAlign::Stretch => cross_avail,
-            _ => cross_natural.min(cross_avail),
-        };
-        let cross_off = match align_items {
-            CrossAlign::Start | CrossAlign::Stretch => 0,
-            CrossAlign::Center => cross_avail.saturating_sub(cross_size) / 2,
-            CrossAlign::End => cross_avail.saturating_sub(cross_size),
-        };
-
-        let child_rect = match axis {
-            Axis::Horizontal => Rect::new(cursor, rect.y + cross_off, m_size, cross_size),
-            Axis::Vertical => Rect::new(rect.x + cross_off, cursor, cross_size, m_size),
-        };
-        child.paint(child_rect, canvas);
-
-        cursor = cursor.saturating_add(m_size);
-        if i + 1 < children.len() {
-            cursor = cursor.saturating_add(gap).saturating_add(extra_gap);
-        }
-    }
-}
-
-fn main_grow_weight(node: &Node, axis: Axis) -> u32 {
-    match node {
-        Node::Sized { w, h, .. } => {
-            let r = match axis {
-                Axis::Horizontal => *w,
-                Axis::Vertical => *h,
-            };
-            r.grow_weight()
-        }
-        _ => 0,
-    }
-}
-
-fn render_grid(
-    cols: &[Track],
-    rows: &[Track],
-    gap: (u32, u32),
-    pad: u32,
-    cells: &[(GridSpan, Node)],
-    rect: Rect,
-    canvas: &mut RgbaImage,
-) {
-    if cols.is_empty() || rows.is_empty() {
-        return;
-    }
-    let inner_w = rect
-        .w
-        .saturating_sub(pad * 2)
-        .saturating_sub(gap.0.saturating_mul(cols.len().saturating_sub(1) as u32));
-    let inner_h = rect
-        .h
-        .saturating_sub(pad * 2)
-        .saturating_sub(gap.1.saturating_mul(rows.len().saturating_sub(1) as u32));
-    let col_widths = solve_tracks(cols, inner_w, |c| {
-        max_natural_in_track(cells, c, true, gap, rect.size())
-    });
-    let row_heights = solve_tracks(rows, inner_h, |r| {
-        max_natural_in_track(cells, r, false, gap, rect.size())
-    });
-
-    // Cumulative offsets.
-    let mut col_off = vec![0u32; cols.len() + 1];
-    for i in 0..cols.len() {
-        col_off[i + 1] = col_off[i] + col_widths[i] + if i + 1 < cols.len() { gap.0 } else { 0 };
-    }
-    let mut row_off = vec![0u32; rows.len() + 1];
-    for i in 0..rows.len() {
-        row_off[i + 1] = row_off[i] + row_heights[i] + if i + 1 < rows.len() { gap.1 } else { 0 };
-    }
-
-    for (span, child) in cells {
-        if span.col >= cols.len() as u32 || span.row >= rows.len() as u32 {
-            continue;
-        }
-        let cs = span.cs().min(cols.len() as u32 - span.col);
-        let rs = span.rs().min(rows.len() as u32 - span.row);
-        let x0 = rect.x + pad + col_off[span.col as usize];
-        let y0 = rect.y + pad + row_off[span.row as usize];
-        let x1 = rect.x + pad + col_off[(span.col + cs) as usize].saturating_sub(gap.0);
-        let y1 = rect.y + pad + row_off[(span.row + rs) as usize].saturating_sub(gap.1);
-        let w = x1.saturating_sub(x0);
-        let h = y1.saturating_sub(y0);
-        child.paint(Rect::new(x0, y0, w, h), canvas);
-    }
-}
-
-// ── Leaf renderers ─────────────────────────────────────────────────────
-
-fn render_image(img: &RgbaImage, mode: Fit, rect: Rect, canvas: &mut RgbaImage) {
-    if rect.w == 0 || rect.h == 0 {
-        return;
-    }
-    let (iw, ih) = (img.width(), img.height());
-    if iw == 0 || ih == 0 {
-        return;
-    }
-    let scaled: Option<RgbaImage> = match mode {
-        Fit::None => None,
-        Fit::Stretch if (iw, ih) != (rect.w, rect.h) => Some(imageops::resize(
-            img,
-            rect.w,
-            rect.h,
-            imageops::FilterType::Triangle,
-        )),
-        Fit::Stretch => None,
-        Fit::Contain | Fit::Cover => {
-            let sx = rect.w as f32 / iw as f32;
-            let sy = rect.h as f32 / ih as f32;
-            let s = if matches!(mode, Fit::Contain) {
-                sx.min(sy)
-            } else {
-                sx.max(sy)
-            };
-            let nw = (iw as f32 * s).round().max(1.0) as u32;
-            let nh = (ih as f32 * s).round().max(1.0) as u32;
-            Some(imageops::resize(
-                img,
-                nw,
-                nh,
-                imageops::FilterType::Triangle,
-            ))
-        }
-    };
-
-    let (src, sw, sh) = match &scaled {
-        Some(s) => (s, s.width(), s.height()),
-        None => (img, iw, ih),
-    };
-
-    let x_off = (rect.w.saturating_sub(sw)) / 2;
-    let y_off = (rect.h.saturating_sub(sh)) / 2;
-
-    if sw <= rect.w && sh <= rect.h {
-        imageops::overlay(
-            canvas,
-            src,
-            rect.x.saturating_add(x_off) as i64,
-            rect.y.saturating_add(y_off) as i64,
-        );
-    } else {
-        let crop_x = (sw.saturating_sub(rect.w)) / 2;
-        let crop_y = (sh.saturating_sub(rect.h)) / 2;
-        let cw = rect.w.min(sw);
-        let ch = rect.h.min(sh);
-        let cropped = imageops::crop_imm(src, crop_x, crop_y, cw, ch).to_image();
-        imageops::overlay(canvas, &cropped, rect.x as i64, rect.y as i64);
-    }
-}
-
-fn render_text(spec: &TextSpec, rect: Rect, canvas: &mut RgbaImage) {
-    let (buf, w, h) = spec.rasterize(rect.w);
-    if w == 0 || h == 0 {
-        return;
-    }
-    let Some(img) = RgbaImage::from_raw(w, h, buf) else {
-        return;
-    };
-    imageops::overlay(canvas, &img, rect.x as i64, rect.y as i64);
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Drawing primitives
-// ════════════════════════════════════════════════════════════════════════
-
-pub fn fill_rect(img: &mut RgbaImage, rect: Rect, color: Color) {
-    let px = Rgba(color);
-    let img_w = img.width();
-    let img_h = img.height();
-    let x_end = rect.x.saturating_add(rect.w).min(img_w);
-    let y_end = rect.y.saturating_add(rect.h).min(img_h);
-    for y in rect.y..y_end {
-        for x in rect.x..x_end {
-            img.put_pixel(x, y, px);
-        }
-    }
-}
-
-pub fn draw_rect_border(img: &mut RgbaImage, rect: Rect, color: Color) {
-    if rect.w == 0 || rect.h == 0 {
-        return;
-    }
-    let px = Rgba(color);
-    let img_w = img.width();
-    let img_h = img.height();
-    let x_end = rect.x.saturating_add(rect.w).min(img_w);
-    let y_end = rect.y.saturating_add(rect.h).min(img_h);
-    for x in rect.x..x_end {
-        if rect.y < img_h {
-            img.put_pixel(x, rect.y, px);
-        }
-        let bot = y_end.saturating_sub(1);
-        if bot < img_h && bot > rect.y {
-            img.put_pixel(x, bot, px);
-        }
-    }
-    for y in rect.y..y_end {
-        if rect.x < img_w {
-            img.put_pixel(rect.x, y, px);
-        }
-        let right = x_end.saturating_sub(1);
-        if right < img_w && right > rect.x {
-            img.put_pixel(right, y, px);
-        }
-    }
-}
-
-// ════════════════════════════════════════════════════════════════════════
-// Label styling
-// ════════════════════════════════════════════════════════════════════════
-
-#[derive(Clone, Debug)]
-pub struct LabelStyle {
-    pub fg: Color,
-    pub bg: Color,
-    pub align: HAlign,
-    pub padding: Insets,
-    /// `None` → auto-fit width via [`font::measure_lines_fitted`].
-    pub char_h: Option<u32>,
-}
-
-impl Default for LabelStyle {
-    fn default() -> Self {
-        Self {
-            fg: rgb(220, 220, 220),
-            bg: rgb(40, 40, 40),
-            align: HAlign::Center,
-            padding: Insets::xy(8, 2),
-            char_h: None,
-        }
-    }
-}
-
-impl LabelStyle {
-    pub fn with_fg(mut self, fg: Color) -> Self {
-        self.fg = fg;
-        self
     }
     pub fn with_bg(mut self, bg: Color) -> Self {
         self.bg = bg;
         self
     }
-    pub fn with_align(mut self, align: HAlign) -> Self {
-        self.align = align;
+    pub fn with_scale(mut self, scale: f32) -> Self {
+        self.scale = scale;
         self
     }
-    pub fn with_padding(mut self, padding: Insets) -> Self {
-        self.padding = padding;
+    pub fn with_base_em(mut self, base_em: u32) -> Self {
+        self.base_em = base_em;
         self
     }
-    pub fn with_char_h(mut self, char_h: u32) -> Self {
-        self.char_h = Some(char_h);
-        self
-    }
-
-    fn strip(&self, s: impl Into<String>) -> Node {
-        let inner = match self.char_h {
-            Some(h) => text(TextSpec::fixed(s, self.fg, self.bg, h)),
-            None => text(TextSpec::lines(vec![(s.into(), self.fg)], self.bg)),
-        };
-        let mut inner: Node = inner.align_h(self.align);
-        if self.padding != Insets::default() {
-            inner = wrap_padded(inner, self.padding);
-        }
-        inner.background(self.bg).fill_width()
-    }
-
-    fn segmented_strip(&self, segments: Vec<LabelSegment>) -> Node {
-        let mut l = layers().child(fill(self.bg));
-        for seg in segments {
-            let txt = match self.char_h.or(seg.char_h) {
-                Some(h) => text(TextSpec::fixed(seg.text, seg.fg, self.bg, h)),
-                None => text(TextSpec::lines(vec![(seg.text, seg.fg)], self.bg)),
-            };
-            l = l.child(txt.align(seg.align, VAlign::Center).padding_xy(
-                self.padding.left.max(self.padding.right),
-                self.padding.top.max(self.padding.bottom),
-            ));
-        }
-        l.fill_width()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct LabelSegment {
-    pub text: String,
-    pub fg: Color,
-    pub align: HAlign,
-    pub char_h: Option<u32>,
-}
-
-impl LabelSegment {
-    pub fn left(text: impl Into<String>, fg: Color) -> Self {
-        Self {
-            text: text.into(),
-            fg,
-            align: HAlign::Left,
-            char_h: None,
-        }
-    }
-    pub fn right(text: impl Into<String>, fg: Color) -> Self {
-        Self {
-            text: text.into(),
-            fg,
-            align: HAlign::Right,
-            char_h: None,
-        }
-    }
-    pub fn center(text: impl Into<String>, fg: Color) -> Self {
-        Self {
-            text: text.into(),
-            fg,
-            align: HAlign::Center,
-            char_h: None,
-        }
-    }
-    pub fn with_char_h(mut self, h: u32) -> Self {
-        self.char_h = Some(h);
+    pub fn with_limits(mut self, limits: LayoutLimits) -> Self {
+        self.limits = limits;
         self
     }
 }
 
-// ════════════════════════════════════════════════════════════════════════
-// Tests
-// ════════════════════════════════════════════════════════════════════════
+/// `em(1.0)` returns `base_em` pixels. `em(0.5)` is half. Reads the
+/// active baseline (set via [`RenderConfig::with_base_em`]; defaults
+/// to [`DEFAULT_BASE_EM`]).
+///
+/// Resolves at call site, so use it inside the same scope where you
+/// build the tree if you want it to track the active baseline.
+pub fn em(units: f32) -> u32 {
+    let base = safety::base_em() as f32;
+    (base * units).round().max(0.0) as u32
+}
+
+// ── Render entry points ───────────────────────────────────────────────
+
+/// Render `tree` against `max_w` using default limits, scale 1, and
+/// black background.
+pub fn render(tree: &Node, max_w: u32) -> RgbaImage {
+    render_with_config(tree, &RenderConfig::new(max_w))
+}
+
+/// As [`render`], with a custom default canvas background.
+pub fn render_with(tree: &Node, max_w: u32, bg: Color) -> RgbaImage {
+    render_with_config(tree, &RenderConfig::new(max_w).with_bg(bg))
+}
+
+/// As [`render_with`], with explicit safety limits.
+pub fn render_with_limits(tree: &Node, max_w: u32, bg: Color, limits: LayoutLimits) -> RgbaImage {
+    render_with_config(
+        tree,
+        &RenderConfig::new(max_w).with_bg(bg).with_limits(limits),
+    )
+}
+
+/// Render `tree` per `cfg` — the full-control entry point.
+///
+/// Applies (in order):
+/// 1. `cfg.base_em` is set as the active em-baseline.
+/// 2. `cfg.limits` is set as the active safety limits.
+/// 3. The tree is walked once via [`Node::scaled`] with `cfg.scale`,
+///    multiplying every fixed-pixel quantity (no-op when `scale == 1.0`).
+/// 4. The constraint width is `cfg.max_w * cfg.scale`.
+/// 5. The canvas is sized to the measured tree, clamped per axis to
+///    `limits.max_dim` and rescaled (preserving aspect) to fit
+///    `limits.max_pixels`.
+pub fn render_with_config(tree: &Node, cfg: &RenderConfig) -> RgbaImage {
+    safety::with_limits(cfg.limits, || {
+        safety::with_base_em(cfg.base_em, || {
+            // Apply scale by walking the tree once. Cheap clone for
+            // scale == 1.0 (returns self without allocation).
+            let scaled = tree.clone().scaled(cfg.scale);
+            let scaled_max_w = ((cfg.max_w as f32) * cfg.scale).round() as u32;
+            let max_w = safety::clamp_dim(scaled_max_w);
+            let root_max = Size::new(max_w, u32::MAX / 2);
+            let measured = safety::clamp_size(scaled.measure(root_max));
+            let s = safety::clamp_to_pixel_budget(measured);
+            let mut canvas = RgbaImage::from_pixel(s.w.max(1), s.h.max(1), Rgba(cfg.bg));
+            scaled.paint(Rect::new(0, 0, s.w, s.h), &mut canvas);
+            canvas
+        })
+    })
+}
+
+/// Render the tree directly into an existing canvas at `rect`. The
+/// caller is responsible for calling this within a
+/// [`safety::with_limits`] scope if non-default caps are wanted.
+pub fn render_into(tree: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    tree.paint(rect, canvas);
+}
 
 #[cfg(test)]
 mod tests {
+    //! Cross-module integration tests — single-module tests live in
+    //! their respective submodules.
+
     use super::*;
-
-    fn solid(w: u32, h: u32, c: Color) -> RgbaImage {
-        RgbaImage::from_pixel(w, h, Rgba(c))
-    }
-
-    // ── Color ──────────────────────────────────────────────────────────
-
-    #[test]
-    fn hex_3_digit() {
-        assert_eq!(hex("#abc"), [0xaa, 0xbb, 0xcc, 255]);
-    }
-    #[test]
-    fn hex_6_digit() {
-        assert_eq!(hex("#1a2b3c"), [0x1a, 0x2b, 0x3c, 255]);
-    }
-    #[test]
-    fn hex_8_digit() {
-        assert_eq!(hex("#11223344"), [0x11, 0x22, 0x33, 0x44]);
-    }
-    #[test]
-    fn hex_no_hash() {
-        assert_eq!(hex("ff0080"), [0xff, 0x00, 0x80, 255]);
-    }
-    #[test]
-    fn rgb_helper_is_opaque() {
-        assert_eq!(rgb(10, 20, 30), [10, 20, 30, 255]);
-    }
-
-    // ── Geometry / measurement ─────────────────────────────────────────
-
-    #[test]
-    fn empty_measures_zero() {
-        assert_eq!(empty().measure(Size::new(100, 100)), Size::ZERO);
-    }
-    #[test]
-    fn image_natural_size() {
-        let n: Node = solid(50, 30, [255, 0, 0, 255]).into();
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(50, 30));
-    }
-    #[test]
-    fn padded_grows_by_insets() {
-        let n = image(solid(50, 30, WHITE)).padding(10);
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(70, 50));
-    }
-    #[test]
-    fn size_overrides() {
-        let n = image(solid(50, 30, WHITE)).size(100, 80);
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(100, 80));
-    }
-    #[test]
-    fn fill_width_consumes_max() {
-        let n = image(solid(50, 30, WHITE)).fill_width();
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(200, 30));
-    }
-
-    // ── Stack ──────────────────────────────────────────────────────────
-
-    #[test]
-    fn column_sums_main_max_cross() {
-        let n = column()
-            .gap(2)
-            .child(image(solid(10, 10, WHITE)))
-            .child(image(solid(20, 5, WHITE)));
-        assert_eq!(n.into_node().measure(Size::new(100, 100)), Size::new(20, 17));
-    }
-    #[test]
-    fn row_sums_main_max_cross() {
-        let n = row()
-            .gap(4)
-            .child(image(solid(10, 10, WHITE)))
-            .child(image(solid(20, 5, WHITE)));
-        assert_eq!(n.into_node().measure(Size::new(100, 100)), Size::new(34, 10));
-    }
-
-    #[test]
-    fn align_items_center_centers_in_cross() {
-        let small = image(solid(10, 10, [255, 0, 0, 255]));
-        let big = image(solid(40, 40, [0, 0, 0, 255]));
-        let n = column()
-            .align_items(CrossAlign::Center)
-            .child(small)
-            .child(big)
-            .render(40);
-        // Small centered within 40 cross-width: red pixel at x=15..25, y=0..9.
-        assert_eq!(n.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
-        assert_eq!(n.get_pixel(0, 5), &Rgba([0, 0, 0, 255]));
-    }
-
-    #[test]
-    fn align_items_stretch_fills_cross() {
-        // Empty has 0 natural height — give the strip explicit height so
-        // it has a main-axis size to paint into.
-        let strip = empty().background([255, 0, 0, 255]).height(SizeRule::Fixed(5));
-        let big = image(solid(40, 40, BLACK));
-        let img = column()
-            .align_items(CrossAlign::Stretch)
-            .child(strip)
-            .child(big)
-            .size(40, 45)
-            .render(40);
-        // Strip stretched to width 40; first row red.
-        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(39, 0), &Rgba([255, 0, 0, 255]));
-    }
-
-    #[test]
-    fn justify_space_between() {
-        let a = image(solid(10, 10, [255, 0, 0, 255]));
-        let b = image(solid(10, 10, [0, 0, 255, 255]));
-        let img = row()
-            .justify(MainAlign::SpaceBetween)
-            .child(a)
-            .child(b)
-            .size(50, 10)
-            .render(50);
-        // a at x=0..10 (red), b at x=40..50 (blue).
-        assert_eq!(img.get_pixel(5, 5), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(45, 5), &Rgba([0, 0, 255, 255]));
-    }
-
-    #[test]
-    fn grow_weights_distribute_remainder() {
-        // Two children: a hug (10px), and a Grow(2). Total stack 60px main.
-        // Hug consumes 10; remainder 50; grow gets all 50.
-        let hug = image(solid(10, 10, [255, 0, 0, 255]));
-        let grow = empty().background([0, 0, 255, 255]).grow(2).fill_height();
-        let img = row()
-            .align_items(CrossAlign::Stretch)
-            .child(hug)
-            .child(grow)
-            .size(60, 10)
-            .render(60);
-        assert_eq!(img.get_pixel(5, 5), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
-    }
-
-    #[test]
-    fn grow_weights_split_2_to_1() {
-        let a = empty().background([255, 0, 0, 255]).grow(2);
-        let b = empty().background([0, 0, 255, 255]).grow(1);
-        let img = row()
-            .align_items(CrossAlign::Stretch)
-            .child(a)
-            .child(b)
-            .size(60, 10)
-            .render(60);
-        // a gets ~40, b gets ~20.
-        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
-    }
-
-    // ── Grid ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn grid_uniform_fr_fills_constraint() {
-        let img = grid()
-            .cols(2)
-            .equal_rows(2)
-            .gap(0)
-            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
-            .cell(1, 0, empty().background([0, 255, 0, 255]).fill())
-            .cell(0, 1, empty().background([0, 0, 255, 255]).fill())
-            .cell(1, 1, empty().background([255, 255, 0, 255]).fill())
-            .size(80, 80)
-            .render(80);
-        assert_eq!(img.get_pixel(20, 20), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(60, 20), &Rgba([0, 255, 0, 255]));
-        assert_eq!(img.get_pixel(20, 60), &Rgba([0, 0, 255, 255]));
-        assert_eq!(img.get_pixel(60, 60), &Rgba([255, 255, 0, 255]));
-    }
-
-    #[test]
-    fn grid_track_px_takes_fixed_size() {
-        let img = grid()
-            .columns([Track::Px(20), Track::Fr(1)])
-            .equal_rows(1)
-            .gap(0)
-            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
-            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
-            .size(100, 10)
-            .render(100);
-        // Px(20) = red on x<20, Fr fills x>=20 with blue.
-        assert_eq!(img.get_pixel(10, 5), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
-    }
-
-    #[test]
-    fn grid_track_auto_hugs_content() {
-        let img = grid()
-            .columns([Track::Auto, Track::Fr(1)])
-            .equal_rows(1)
-            .gap(0)
-            .cell(0, 0, image(solid(15, 10, [255, 0, 0, 255])))
-            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
-            .size(100, 10)
-            .render(100);
-        // Auto col = 15 wide (red), Fr fills rest (blue).
-        assert_eq!(img.get_pixel(7, 5), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
-    }
-
-    #[test]
-    fn grid_areas_parses_template() {
-        let img = grid()
-            .areas(&["title title", "exp   act"])
-            .row_heights([Track::Px(10), Track::Px(20)])
-            .gap(0)
-            .place("title", empty().background([255, 0, 0, 255]).fill())
-            .place("exp", empty().background([0, 255, 0, 255]).fill())
-            .place("act", empty().background([0, 0, 255, 255]).fill())
-            .size(40, 30)
-            .render(40);
-        // Title row spans 0..40, height 10 → red at top.
-        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
-        // exp/act split at x=20, y=10..30.
-        assert_eq!(img.get_pixel(10, 20), &Rgba([0, 255, 0, 255]));
-        assert_eq!(img.get_pixel(30, 20), &Rgba([0, 0, 255, 255]));
-    }
-
-    #[test]
-    fn grid_span_via_areas() {
-        let img = grid()
-            .areas(&["banner banner", "a a"])
-            .equal_rows(2)
-            .gap(0)
-            .place("banner", empty().background([0, 255, 0, 255]).fill())
-            .place("a", empty().background([255, 0, 0, 255]).fill())
-            .size(40, 40)
-            .render(40);
-        // Banner spans both columns of row 0.
-        assert_eq!(img.get_pixel(10, 10), &Rgba([0, 255, 0, 255]));
-        assert_eq!(img.get_pixel(30, 10), &Rgba([0, 255, 0, 255]));
-        assert_eq!(img.get_pixel(20, 30), &Rgba([255, 0, 0, 255]));
-    }
-
-    // ── Layers / modifiers ─────────────────────────────────────────────
-
-    #[test]
-    fn layers_painters_order() {
-        let bg = empty().background([255, 0, 0, 255]).fill();
-        let dot = image(solid(4, 4, [0, 255, 0, 255])).center();
-        let img = layers().child(bg).child(dot).size(20, 20).render(20);
-        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
-        assert_eq!(img.get_pixel(10, 10), &Rgba([0, 255, 0, 255]));
-    }
-
-    #[test]
-    fn align_centers_in_oversized_rect() {
-        let img = image(solid(20, 10, [255, 255, 0, 255]))
-            .center()
-            .size(100, 60)
-            .render(100);
-        assert_eq!(img.get_pixel(50, 30), &Rgba([255, 255, 0, 255]));
-        assert_eq!(img.get_pixel(0, 0), &Rgba([0, 0, 0, 255]));
-    }
-
-    #[test]
-    fn background_paints_first() {
-        let img = empty().background([10, 20, 30, 255]).size(20, 20).render(20);
-        assert_eq!(img.get_pixel(5, 5), &Rgba([10, 20, 30, 255]));
-    }
-
-    #[test]
-    fn border_paints_outline() {
-        let img = empty()
-            .background(BLACK)
-            .border(WHITE)
-            .size(10, 10)
-            .render(10);
-        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 255, 255, 255]));
-        assert_eq!(img.get_pixel(9, 0), &Rgba([255, 255, 255, 255]));
-        assert_eq!(img.get_pixel(5, 5), &Rgba([0, 0, 0, 255]));
-    }
-
-    #[test]
-    fn fit_contain_letterboxes() {
-        let img = image(solid(20, 10, [255, 0, 0, 255]))
-            .fit_contain()
-            .size(40, 40)
-            .render(40);
-        assert_eq!(img.get_pixel(20, 0), &Rgba([0, 0, 0, 255]));
-        assert_eq!(img.get_pixel(20, 20), &Rgba([255, 0, 0, 255]));
-    }
-
-    // ── min/max/aspect ─────────────────────────────────────────────────
-
-    #[test]
-    fn min_width_grows_to_minimum() {
-        let n = image(solid(10, 10, WHITE)).min_width(50);
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(50, 10));
-    }
-    #[test]
-    fn max_width_caps_natural() {
-        let n = image(solid(80, 10, WHITE)).max_width(40);
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(40, 10));
-    }
-    #[test]
-    fn aspect_ratio_16_9_from_width() {
-        let n = image(solid(160, 50, WHITE)).aspect_ratio(16, 9);
-        // cw=160, h_from_w = 160*9/16 = 90 → (160, 90)
-        assert_eq!(n.measure(Size::new(200, 200)), Size::new(160, 90));
-    }
-
-    // ── Text ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn text_lines_measures_match_render() {
-        let spec = TextSpec::lines(
-            vec![("HELLO".to_string(), WHITE), ("WORLD!".to_string(), WHITE)],
-            BLACK,
-        );
-        let measured = spec.natural(200);
-        let (_, w, h) = spec.rasterize(200);
-        assert_eq!(measured, Size::new(w, h));
-    }
-    #[test]
-    fn from_str_makes_text_node() {
-        let n: Node = "hello".into();
-        assert!(matches!(n, Node::Text(_)));
-    }
-
-    // ── Label ──────────────────────────────────────────────────────────
-
-    #[test]
-    fn label_default_strip_above_image() {
-        let img = image(solid(40, 40, [255, 0, 0, 255])).label("EXPECTED");
-        let s = img.measure(Size::new(400, 400));
-        assert!(s.h > 40);
-    }
-    #[test]
-    fn label_styled_uses_provided_bg() {
-        let style = LabelStyle::default()
-            .with_bg(rgb(100, 0, 0))
-            .with_fg(rgb(255, 255, 0));
-        let canvas = image(solid(40, 40, [255, 0, 0, 255]))
-            .label_styled("HELLO", &style)
-            .width(SizeRule::Fixed(40))
-            .render(40);
-        assert_eq!(canvas.get_pixel(0, 0), &Rgba([100, 0, 0, 255]));
-    }
-
-    // ── Builder fluency smoke tests ────────────────────────────────────
+    use image::Rgba;
 
     #[test]
     fn builder_chain_produces_node() {
@@ -2188,10 +233,15 @@ mod tests {
             .gap(8)
             .align_items(CrossAlign::Center)
             .child("hi")
-            .child(image(solid(10, 10, WHITE)))
+            .child(image(image::RgbaImage::from_pixel(
+                10,
+                10,
+                Rgba([255, 255, 255, 255]),
+            )))
             .padding(4)
             .background(hex("#123456"));
     }
+
     #[test]
     fn implicit_str_to_text_in_builder() {
         let n: Node = row().child("a").child("b").into();
@@ -2201,5 +251,196 @@ mod tests {
         } else {
             panic!("expected Stack");
         }
+    }
+
+    #[test]
+    fn text_in_vstack_hugs_then_takes_full_width_cross() {
+        let n = column()
+            .gap(0)
+            .child(line("EXPECTED", WHITE).background(BLACK));
+        let s = Node::from(n).measure(Size::new(400, 400));
+        assert!(s.w > 0 && s.w <= 400);
+        assert!(s.h > 0);
+    }
+
+    // ── Safety / hostile-tree tests ────────────────────────────────
+
+    fn default_max_dim() -> u32 {
+        LayoutLimits::default().max_dim
+    }
+
+    #[test]
+    fn safety_fixed_size_is_capped() {
+        let n = empty().size(u32::MAX, u32::MAX);
+        let s = n.measure(Size::new(4096, 4096));
+        assert!(s.w <= default_max_dim());
+        assert!(s.h <= default_max_dim());
+    }
+
+    #[test]
+    fn safety_fr_falls_back_to_auto_when_unbounded() {
+        // Without the fallback this would measure to u32::MAX/2 height.
+        let n = grid()
+            .cols(2)
+            .equal_rows(2)
+            .cell(
+                0,
+                0,
+                image(image::RgbaImage::from_pixel(20, 20, image::Rgba(WHITE))),
+            )
+            .cell(
+                1,
+                0,
+                image(image::RgbaImage::from_pixel(20, 20, image::Rgba(WHITE))),
+            )
+            .cell(
+                0,
+                1,
+                image(image::RgbaImage::from_pixel(20, 20, image::Rgba(WHITE))),
+            )
+            .cell(
+                1,
+                1,
+                image(image::RgbaImage::from_pixel(20, 20, image::Rgba(WHITE))),
+            );
+        let canvas = render(&Node::from(n), 200);
+        assert!(canvas.height() < default_max_dim());
+    }
+
+    #[test]
+    fn safety_canvas_alloc_clamped() {
+        let n = empty().size(u32::MAX, u32::MAX).background(BLACK);
+        let canvas = render(&n, u32::MAX);
+        // Per-axis cap.
+        assert!(canvas.width() <= default_max_dim());
+        assert!(canvas.height() <= default_max_dim());
+        // Total-pixel cap.
+        let total = canvas.width() as u64 * canvas.height() as u64;
+        assert!(total <= LayoutLimits::default().max_pixels as u64);
+    }
+
+    #[test]
+    fn safety_pixel_budget_scales_huge_canvas_down() {
+        // 8192 × 8192 = 67 MP, but DEFAULT.max_pixels = 20 MP.
+        let n = empty().size(8192, 8192).background(BLACK);
+        let canvas = render(&n, 8192);
+        let total = canvas.width() as u64 * canvas.height() as u64;
+        assert!(total <= LayoutLimits::default().max_pixels as u64);
+    }
+
+    #[test]
+    fn safety_permissive_allows_more_pixels() {
+        let n = empty().size(8192, 8192).background(BLACK);
+        let canvas = render_with_limits(&n, 8192, BLACK, LayoutLimits::PERMISSIVE);
+        // Permissive caps at 200 MP — the full 67 MP canvas fits.
+        let total = canvas.width() as u64 * canvas.height() as u64;
+        assert!(total > 60_000_000);
+    }
+
+    #[test]
+    fn safety_strict_clamps_more_aggressively() {
+        let n = empty().size(8192, 8192).background(BLACK);
+        let canvas = render_with_limits(&n, 8192, BLACK, LayoutLimits::STRICT);
+        // Strict: 4 MP budget.
+        let total = canvas.width() as u64 * canvas.height() as u64;
+        assert!(total <= LayoutLimits::STRICT.max_pixels as u64);
+    }
+
+    #[test]
+    fn safety_deep_nesting_does_not_overflow_stack() {
+        let mut n: Node = empty().size(10, 10);
+        for _ in 0..200 {
+            n = n.padding(0);
+        }
+        let _ = n.measure(Size::new(100, 100));
+        let _ = render(&n, 100);
+    }
+
+    #[test]
+    fn safety_huge_child_count_is_truncated() {
+        let mut s = row();
+        for _ in 0..10_000 {
+            s = s.child(empty().size(1, 1));
+        }
+        let measured = Node::from(s).measure(Size::new(2000, 100));
+        assert!(measured.w <= default_max_dim());
+    }
+
+    // ── Percent / scale / em ───────────────────────────────────────
+
+    #[test]
+    fn percent_width_takes_half_of_constraint() {
+        let n = empty().width_percent(0.5);
+        let s = n.measure(Size::new(400, 200));
+        assert_eq!(s.w, 200);
+    }
+    #[test]
+    fn percent_size_takes_quarter() {
+        let n = empty().size_percent(0.25, 0.5);
+        let s = n.measure(Size::new(400, 200));
+        assert_eq!(s, Size::new(100, 100));
+    }
+    #[test]
+    fn track_percent_consumes_proportional() {
+        let img = grid()
+            .columns([Track::Percent(0.25), Track::Percent(0.75)])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(100, 10)
+            .render(100);
+        // 25% / 75% split → red x=0..24, blue x=25..99.
+        assert_eq!(img.get_pixel(10, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+        assert_eq!(img.get_pixel(90, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn scale_factor_doubles_fixed_quantities() {
+        // A 100×40 fixed-size node, rendered at scale=2 → 200×80 canvas.
+        let n = empty().background(WHITE).size(100, 40);
+        let canvas = render_with_config(&n, &RenderConfig::new(100).with_scale(2.0));
+        assert_eq!(canvas.width(), 200);
+        assert_eq!(canvas.height(), 80);
+    }
+    #[test]
+    fn scale_factor_leaves_percent_alone() {
+        // Percent is already relative; max_w doubles, so percent of
+        // max_w doubles too — but the percent value itself is unchanged.
+        let n = empty().background(WHITE).width_percent(0.5);
+        let canvas = render_with_config(&n, &RenderConfig::new(200).with_scale(2.0).with_bg(BLACK));
+        // max_w = 200 * 2 = 400 px, width_percent(0.5) = 200 px wide.
+        assert_eq!(canvas.width(), 200);
+    }
+
+    #[test]
+    fn em_uses_base_em() {
+        // Default base_em = 16, so em(1.0) = 16, em(0.5) = 8.
+        let n = empty().background(WHITE).size(em(2.0), em(1.0));
+        let canvas = render(&n, 100);
+        assert_eq!(canvas.width(), 32);
+        assert_eq!(canvas.height(), 16);
+    }
+    #[test]
+    fn em_with_custom_base() {
+        // em() resolves at call time, so we need to build inside the
+        // RenderConfig scope. We do that by computing em() within a
+        // closure passed to render_with_config; direct render() uses
+        // the default base. Demonstrated via with_base_em scope.
+        super::safety::with_base_em(20, || {
+            assert_eq!(em(1.0), 20);
+            assert_eq!(em(0.5), 10);
+            assert_eq!(em(2.5), 50);
+        });
+        // Reset.
+        assert_eq!(em(1.0), 16);
+    }
+
+    #[test]
+    fn safety_huge_char_h_is_clamped() {
+        let n = text(TextSpec::fixed("x", WHITE, BLACK, u32::MAX)).background(BLACK);
+        let s = n.measure(Size::new(1000, 1000));
+        assert!(s.h <= default_max_dim());
     }
 }

--- a/zensim-regress/src/layout/color.rs
+++ b/zensim-regress/src/layout/color.rs
@@ -1,0 +1,90 @@
+//! Color type, named constants, and CSS-style constructors.
+
+/// RGBA color (straight alpha — the `image` crate's storage convention).
+pub type Color = [u8; 4];
+
+pub const WHITE: Color = [255, 255, 255, 255];
+pub const BLACK: Color = [0, 0, 0, 255];
+pub const TRANSPARENT: Color = [0, 0, 0, 0];
+
+/// Build an opaque RGB color.
+pub const fn rgb(r: u8, g: u8, b: u8) -> Color {
+    [r, g, b, 255]
+}
+
+/// Build an RGBA color.
+pub const fn rgba(r: u8, g: u8, b: u8, a: u8) -> Color {
+    [r, g, b, a]
+}
+
+/// Parse a CSS-style hex color: `#RGB`, `#RRGGBB`, or `#RRGGBBAA`. The
+/// leading `#` is optional. Panics at compile time (or runtime, if not
+/// in a const context) on malformed input.
+pub const fn hex(s: &str) -> Color {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let start = if len > 0 && bytes[0] == b'#' { 1 } else { 0 };
+    let n = len - start;
+
+    if n == 3 {
+        let r = hex1(bytes[start]) * 17;
+        let g = hex1(bytes[start + 1]) * 17;
+        let b = hex1(bytes[start + 2]) * 17;
+        [r, g, b, 255]
+    } else if n == 6 {
+        [
+            hex2(bytes[start], bytes[start + 1]),
+            hex2(bytes[start + 2], bytes[start + 3]),
+            hex2(bytes[start + 4], bytes[start + 5]),
+            255,
+        ]
+    } else if n == 8 {
+        [
+            hex2(bytes[start], bytes[start + 1]),
+            hex2(bytes[start + 2], bytes[start + 3]),
+            hex2(bytes[start + 4], bytes[start + 5]),
+            hex2(bytes[start + 6], bytes[start + 7]),
+        ]
+    } else {
+        panic!("invalid hex color literal — expected #RGB, #RRGGBB, or #RRGGBBAA")
+    }
+}
+
+const fn hex2(hi: u8, lo: u8) -> u8 {
+    hex1(hi) * 16 + hex1(lo)
+}
+
+const fn hex1(b: u8) -> u8 {
+    match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'f' => b - b'a' + 10,
+        b'A'..=b'F' => b - b'A' + 10,
+        _ => panic!("invalid hex digit"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_3_digit() {
+        assert_eq!(hex("#abc"), [0xaa, 0xbb, 0xcc, 255]);
+    }
+    #[test]
+    fn hex_6_digit() {
+        assert_eq!(hex("#1a2b3c"), [0x1a, 0x2b, 0x3c, 255]);
+    }
+    #[test]
+    fn hex_8_digit() {
+        assert_eq!(hex("#11223344"), [0x11, 0x22, 0x33, 0x44]);
+    }
+    #[test]
+    fn hex_no_hash() {
+        assert_eq!(hex("ff0080"), [0xff, 0x00, 0x80, 255]);
+    }
+    #[test]
+    fn rgb_helper_is_opaque() {
+        assert_eq!(rgb(10, 20, 30), [10, 20, 30, 255]);
+    }
+}

--- a/zensim-regress/src/layout/geom.rs
+++ b/zensim-regress/src/layout/geom.rs
@@ -1,0 +1,108 @@
+//! Geometric primitives: sizes, rectangles, insets, and alignment enums.
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Size {
+    pub w: u32,
+    pub h: u32,
+}
+
+impl Size {
+    pub const fn new(w: u32, h: u32) -> Self {
+        Self { w, h }
+    }
+    pub const ZERO: Self = Self { w: 0, h: 0 };
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Rect {
+    pub x: u32,
+    pub y: u32,
+    pub w: u32,
+    pub h: u32,
+}
+
+impl Rect {
+    pub const fn new(x: u32, y: u32, w: u32, h: u32) -> Self {
+        Self { x, y, w, h }
+    }
+    pub const fn size(&self) -> Size {
+        Size::new(self.w, self.h)
+    }
+}
+
+/// Padding-style insets — one value per edge.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct Insets {
+    pub left: u32,
+    pub top: u32,
+    pub right: u32,
+    pub bottom: u32,
+}
+
+impl Insets {
+    pub const fn all(v: u32) -> Self {
+        Self {
+            left: v,
+            top: v,
+            right: v,
+            bottom: v,
+        }
+    }
+    /// Symmetric `(x, y)` — same horizontal, same vertical.
+    pub const fn xy(x: u32, y: u32) -> Self {
+        Self {
+            left: x,
+            top: y,
+            right: x,
+            bottom: y,
+        }
+    }
+    /// CSS shorthand order: top, right, bottom, left.
+    pub const fn each(top: u32, right: u32, bottom: u32, left: u32) -> Self {
+        Self {
+            top,
+            right,
+            bottom,
+            left,
+        }
+    }
+    pub const fn horizontal(&self) -> u32 {
+        self.left + self.right
+    }
+    pub const fn vertical(&self) -> u32 {
+        self.top + self.bottom
+    }
+
+    /// Multiply each edge by `scale` (rounded).
+    pub(super) fn scaled(self, scale: f32) -> Self {
+        let s = |v: u32| ((v as f32) * scale).round() as u32;
+        Self {
+            left: s(self.left),
+            top: s(self.top),
+            right: s(self.right),
+            bottom: s(self.bottom),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum HAlign {
+    Left,
+    #[default]
+    Center,
+    Right,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum VAlign {
+    Top,
+    #[default]
+    Center,
+    Bottom,
+}

--- a/zensim-regress/src/layout/grid.rs
+++ b/zensim-regress/src/layout/grid.rs
@@ -1,0 +1,755 @@
+//! 2D grid container — CSS `display: grid` with `grid-template-columns`
+//! / `-rows`. Tracks can be `Px`, `Fr` (weighted fill of remainder), or
+//! `Auto` (hug content). Supports cell spanning and CSS-style ASCII
+//! `grid-template-areas`.
+
+use std::collections::HashMap;
+
+use image::RgbaImage;
+
+use super::geom::{Rect, Size};
+use super::node::Node;
+use super::safety;
+use super::sizing::Track;
+
+/// Position of a child within a [`Grid`] — column/row origin and span.
+///
+/// `colspan == 0` and `rowspan == 0` are normalized to `1` during
+/// layout.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GridSpan {
+    pub col: u32,
+    pub row: u32,
+    pub colspan: u32,
+    pub rowspan: u32,
+}
+
+impl GridSpan {
+    pub const fn cell(col: u32, row: u32) -> Self {
+        Self {
+            col,
+            row,
+            colspan: 1,
+            rowspan: 1,
+        }
+    }
+    pub const fn span(col: u32, row: u32, colspan: u32, rowspan: u32) -> Self {
+        Self {
+            col,
+            row,
+            colspan,
+            rowspan,
+        }
+    }
+    fn cs(&self) -> u32 {
+        self.colspan.max(1)
+    }
+    fn rs(&self) -> u32 {
+        self.rowspan.max(1)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Grid {
+    cols: Vec<Track>,
+    rows: Vec<Track>,
+    gap: (u32, u32),
+    pad: u32,
+    cells: Vec<(GridSpan, Node)>,
+    areas: HashMap<String, GridSpan>,
+}
+
+impl Grid {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn columns(mut self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.cols = tracks.into_iter().collect();
+        self
+    }
+    pub fn rows(mut self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.rows = tracks.into_iter().collect();
+        self
+    }
+    /// Alias for [`Grid::columns`] — reads better paired with [`Grid::row_heights`].
+    pub fn col_widths(self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.columns(tracks)
+    }
+    pub fn row_heights(self, tracks: impl IntoIterator<Item = Track>) -> Self {
+        self.rows(tracks)
+    }
+    /// Equal-weight Fr columns: `vec![Track::Fr(1); n]`.
+    pub fn cols(mut self, n: u32) -> Self {
+        self.cols = (0..n).map(|_| Track::Fr(1)).collect();
+        self
+    }
+    pub fn equal_rows(mut self, n: u32) -> Self {
+        self.rows = (0..n).map(|_| Track::Fr(1)).collect();
+        self
+    }
+
+    pub fn gap(mut self, g: u32) -> Self {
+        self.gap = (g, g);
+        self
+    }
+    pub fn gap_xy(mut self, x: u32, y: u32) -> Self {
+        self.gap = (x, y);
+        self
+    }
+    pub fn padding(mut self, p: u32) -> Self {
+        self.pad = p;
+        self
+    }
+
+    pub fn cell(mut self, col: u32, row: u32, n: impl Into<Node>) -> Self {
+        self.cells.push((GridSpan::cell(col, row), n.into()));
+        self
+    }
+    pub fn span(
+        mut self,
+        col: u32,
+        row: u32,
+        colspan: u32,
+        rowspan: u32,
+        n: impl Into<Node>,
+    ) -> Self {
+        self.cells
+            .push((GridSpan::span(col, row, colspan, rowspan), n.into()));
+        self
+    }
+
+    /// Define named areas via an ASCII-art template — like CSS
+    /// `grid-template-areas`. Each row is whitespace-separated; `.` is
+    /// empty. Repeated tokens form a single area whose bounding box is
+    /// the contiguous extent of those tokens. All rows must have the
+    /// same column count (panics otherwise).
+    ///
+    /// If `cols`/`rows` haven't been set explicitly, equal-weight Fr
+    /// tracks are inferred from the template's dimensions.
+    pub fn areas(mut self, rows: &[&str]) -> Self {
+        if rows.is_empty() {
+            return self;
+        }
+        let row_tokens: Vec<Vec<&str>> = rows
+            .iter()
+            .map(|r| r.split_whitespace().collect())
+            .collect();
+        let cols_count = row_tokens[0].len() as u32;
+        for (i, r) in row_tokens.iter().enumerate() {
+            assert_eq!(
+                r.len() as u32,
+                cols_count,
+                "Grid::areas row {i} has {} cols, expected {cols_count}",
+                r.len()
+            );
+        }
+        let rows_count = rows.len() as u32;
+
+        let mut bbox: HashMap<String, (u32, u32, u32, u32)> = HashMap::new();
+        for (r, line) in row_tokens.iter().enumerate() {
+            for (c, tok) in line.iter().enumerate() {
+                if *tok == "." {
+                    continue;
+                }
+                let key = (*tok).to_string();
+                let entry = bbox
+                    .entry(key)
+                    .or_insert((c as u32, r as u32, c as u32, r as u32));
+                entry.0 = entry.0.min(c as u32);
+                entry.1 = entry.1.min(r as u32);
+                entry.2 = entry.2.max(c as u32);
+                entry.3 = entry.3.max(r as u32);
+            }
+        }
+        self.areas = bbox
+            .into_iter()
+            .map(|(name, (c0, r0, c1, r1))| {
+                (name, GridSpan::span(c0, r0, c1 - c0 + 1, r1 - r0 + 1))
+            })
+            .collect();
+
+        if self.cols.is_empty() {
+            self.cols = (0..cols_count).map(|_| Track::Fr(1)).collect();
+        }
+        if self.rows.is_empty() {
+            self.rows = (0..rows_count).map(|_| Track::Fr(1)).collect();
+        }
+        self
+    }
+
+    /// Place a child in a named area defined by [`Grid::areas`].
+    /// Panics if `name` is unknown.
+    pub fn place(mut self, name: &str, n: impl Into<Node>) -> Self {
+        let span = *self
+            .areas
+            .get(name)
+            .unwrap_or_else(|| panic!("Grid::place: no area named {name:?}"));
+        self.cells.push((span, n.into()));
+        self
+    }
+}
+
+impl From<Grid> for Node {
+    fn from(g: Grid) -> Node {
+        Node::Grid {
+            cols: g.cols,
+            rows: g.rows,
+            gap: g.gap,
+            pad: g.pad,
+            cells: g.cells,
+        }
+    }
+}
+
+/// Free-fn entry point for an empty [`Grid`] builder.
+pub fn grid() -> Grid {
+    Grid::new()
+}
+
+// ── Track sizing ───────────────────────────────────────────────────────
+
+/// Solve track sizes given total available space along that axis.
+///
+/// Order: Px tracks consume their fixed size, Auto tracks call back to
+/// `auto_size` for their content size, then the remainder is split among
+/// Fr tracks proportionally to their weight (last Fr gets any rounding
+/// leftover so we don't lose pixels to integer division).
+///
+/// **Safety:** when `available` is large enough to be considered
+/// unbounded (e.g., the root render's `u32::MAX/2` for the vertical
+/// axis), Fr tracks fall back to [`Track::Auto`] semantics rather
+/// than expanding to fill an effectively infinite axis.
+#[allow(clippy::manual_checked_ops)]
+fn solve_tracks(tracks: &[Track], available: u32, auto_size: impl Fn(u32) -> u32) -> Vec<u32> {
+    let mut sizes = vec![0u32; tracks.len()];
+    let mut consumed = 0u32;
+    let mut total_fr = 0u32;
+    let unbounded = safety::is_unbounded(available);
+    let n = safety::cap_tracks(tracks.len());
+
+    for (i, t) in tracks.iter().take(n).enumerate() {
+        match t {
+            Track::Px(v) => {
+                let v = safety::clamp_dim(*v);
+                sizes[i] = v;
+                consumed = consumed.saturating_add(v);
+            }
+            Track::Auto => {
+                let v = safety::clamp_dim(auto_size(i as u32));
+                sizes[i] = v;
+                consumed = consumed.saturating_add(v);
+            }
+            Track::Percent(p) => {
+                let p = if p.is_nan() { 0.0 } else { p.clamp(0.0, 1.0) };
+                let v = safety::clamp_dim(((available as f32) * p).round() as u32);
+                sizes[i] = v;
+                consumed = consumed.saturating_add(v);
+            }
+            Track::Fr(w) => {
+                if unbounded {
+                    // Fall back to Auto in unbounded constraints so a
+                    // hostile tree can't request a 4-TB canvas.
+                    let v = safety::clamp_dim(auto_size(i as u32));
+                    sizes[i] = v;
+                    consumed = consumed.saturating_add(v);
+                } else {
+                    total_fr = total_fr.saturating_add(*w);
+                }
+            }
+            Track::FrMin { weight, min_px } => {
+                if unbounded {
+                    // Unbounded constraint: take just the min_px (no
+                    // remainder to distribute fractionally).
+                    let v = safety::clamp_dim(*min_px);
+                    sizes[i] = v;
+                    consumed = consumed.saturating_add(v);
+                } else {
+                    total_fr = total_fr.saturating_add(*weight);
+                }
+            }
+        }
+    }
+    if total_fr > 0 {
+        // Iterative freeze pass — for each FrMin track whose proportional
+        // share of the remainder would fall below its min_px, freeze it
+        // at min_px and reduce the remainder + total_fr accordingly.
+        // Repeat until stable (each freeze can push another FrMin below
+        // its min). For [FrMin] only, this terminates in 1 iteration;
+        // for mixed Fr/FrMin, in at most `count(FrMin)` iterations.
+        let mut frozen = vec![false; tracks.len()];
+        let mut remainder = available.saturating_sub(consumed);
+        loop {
+            let mut any = false;
+            for (i, t) in tracks.iter().take(n).enumerate() {
+                if frozen[i] {
+                    continue;
+                }
+                if let Track::FrMin { weight, min_px } = t {
+                    let share = if total_fr > 0 {
+                        ((remainder as u64) * (*weight as u64) / (total_fr as u64)) as u32
+                    } else {
+                        0
+                    };
+                    let min = safety::clamp_dim(*min_px);
+                    if share < min {
+                        sizes[i] = min;
+                        consumed = consumed.saturating_add(min);
+                        remainder = remainder.saturating_sub(min);
+                        total_fr = total_fr.saturating_sub(*weight);
+                        frozen[i] = true;
+                        any = true;
+                    }
+                }
+            }
+            if !any {
+                break;
+            }
+        }
+
+        // Distribute the (possibly reduced) remainder among the still-
+        // unfrozen Fr / FrMin tracks proportional to weight. Last
+        // unfrozen track absorbs any rounding remainder.
+        let mut allotted = 0u32;
+        let mut last_idx: Option<usize> = None;
+        for (i, t) in tracks.iter().take(n).enumerate() {
+            if frozen[i] {
+                continue;
+            }
+            let weight = match t {
+                Track::Fr(w) => *w,
+                Track::FrMin { weight, .. } => *weight,
+                _ => continue,
+            };
+            let share = if total_fr > 0 {
+                ((remainder as u64) * (weight as u64) / (total_fr as u64)) as u32
+            } else {
+                0
+            };
+            sizes[i] = safety::clamp_dim(share);
+            allotted = allotted.saturating_add(sizes[i]);
+            last_idx = Some(i);
+        }
+        if let Some(i) = last_idx {
+            sizes[i] =
+                safety::clamp_dim(sizes[i].saturating_add(remainder.saturating_sub(allotted)));
+        }
+    } else if !unbounded {
+        // No Fr/FrMin tracks at all and content overflowed `available`.
+        // Proportionally shrink Auto tracks so the row fits in
+        // `available` (Px and Percent are honored as-is — they were
+        // explicitly sized by the caller). This trades CSS-grid
+        // max-content semantics for graceful degradation when content
+        // would otherwise paint past the row.
+        let total: u32 = sizes.iter().sum();
+        if total > available && available > 0 {
+            let mut auto_total = 0u32;
+            for (i, t) in tracks.iter().take(n).enumerate() {
+                if matches!(t, Track::Auto) {
+                    auto_total = auto_total.saturating_add(sizes[i]);
+                }
+            }
+            let non_auto: u32 = total.saturating_sub(auto_total);
+            let auto_budget = available.saturating_sub(non_auto);
+            if auto_total > auto_budget && auto_total > 0 {
+                let mut allotted = 0u32;
+                let mut last_auto: Option<usize> = None;
+                for (i, t) in tracks.iter().take(n).enumerate() {
+                    if matches!(t, Track::Auto) {
+                        let share =
+                            ((sizes[i] as u64) * (auto_budget as u64) / (auto_total as u64)) as u32;
+                        sizes[i] = share;
+                        allotted = allotted.saturating_add(share);
+                        last_auto = Some(i);
+                    }
+                }
+                if let Some(i) = last_auto {
+                    sizes[i] = sizes[i].saturating_add(auto_budget.saturating_sub(allotted));
+                }
+            }
+        }
+    }
+
+    // FrMin/Fr-with-Auto overflow case: same shrink logic, applied
+    // after the Fr distribution pass. If sum still exceeds available,
+    // shrink Auto tracks proportionally to fit (leaving Fr/FrMin sizes
+    // alone — they've already negotiated their minimums).
+    if !unbounded && total_fr > 0 {
+        let total: u32 = sizes.iter().sum();
+        if total > available && available > 0 {
+            let mut auto_total = 0u32;
+            for (i, t) in tracks.iter().take(n).enumerate() {
+                if matches!(t, Track::Auto) {
+                    auto_total = auto_total.saturating_add(sizes[i]);
+                }
+            }
+            let non_auto: u32 = total.saturating_sub(auto_total);
+            let auto_budget = available.saturating_sub(non_auto);
+            if auto_total > auto_budget && auto_total > 0 {
+                let mut allotted = 0u32;
+                let mut last_auto: Option<usize> = None;
+                for (i, t) in tracks.iter().take(n).enumerate() {
+                    if matches!(t, Track::Auto) {
+                        let share =
+                            ((sizes[i] as u64) * (auto_budget as u64) / (auto_total as u64)) as u32;
+                        sizes[i] = share;
+                        allotted = allotted.saturating_add(share);
+                        last_auto = Some(i);
+                    }
+                }
+                if let Some(i) = last_auto {
+                    sizes[i] = sizes[i].saturating_add(auto_budget.saturating_sub(allotted));
+                }
+            }
+        }
+    }
+
+    sizes
+}
+
+/// For Auto-track sizing — find the max natural size of any cell whose
+/// span includes track index `idx`, divided by span length so a child
+/// spanning N tracks contributes 1/N to each.
+///
+/// The relevant axis is measured with effectively unbounded space so
+/// children report their *content* size, not a size clamped to the
+/// container's constraint — that's the CSS-grid `auto` (max-content)
+/// semantics. The cross axis stays bounded.
+fn max_natural_in_track(
+    cells: &[(GridSpan, Node)],
+    idx: u32,
+    is_col: bool,
+    gap: (u32, u32),
+    max: Size,
+) -> u32 {
+    let mut out = 0u32;
+    let n = safety::cap_cells(cells.len());
+    let big = safety::limits().max_dim;
+    let measure_max = if is_col {
+        Size::new(big, max.h)
+    } else {
+        Size::new(max.w, big)
+    };
+    for (span, child) in cells.iter().take(n) {
+        let (start, len) = if is_col {
+            (span.col, span.cs())
+        } else {
+            (span.row, span.rs())
+        };
+        if idx < start || idx >= start + len {
+            continue;
+        }
+        let s = child.measure(measure_max);
+        let dim = if is_col { s.w } else { s.h };
+        let internal_gap = if is_col { gap.0 } else { gap.1 };
+        let spread = dim
+            .saturating_sub(internal_gap.saturating_mul(len.saturating_sub(1)))
+            .div_ceil(len.max(1));
+        out = out.max(spread);
+    }
+    safety::clamp_dim(out)
+}
+
+// ── Measure / paint ────────────────────────────────────────────────────
+
+pub(super) fn measure(
+    cols: &[Track],
+    rows: &[Track],
+    gap: (u32, u32),
+    pad: u32,
+    cells: &[(GridSpan, Node)],
+    max: Size,
+) -> Size {
+    if cols.is_empty() || rows.is_empty() {
+        return Size::ZERO;
+    }
+    let inner_w = max
+        .w
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.0.saturating_mul(cols.len().saturating_sub(1) as u32));
+    let inner_h = max
+        .h
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.1.saturating_mul(rows.len().saturating_sub(1) as u32));
+    let col_widths = solve_tracks(cols, inner_w, |c| {
+        max_natural_in_track(cells, c, true, gap, max)
+    });
+    let row_heights = solve_tracks(rows, inner_h, |r| {
+        max_natural_in_track(cells, r, false, gap, max)
+    });
+    let total_w =
+        pad * 2 + col_widths.iter().sum::<u32>() + gap.0.saturating_mul(cols.len() as u32 - 1);
+    let total_h =
+        pad * 2 + row_heights.iter().sum::<u32>() + gap.1.saturating_mul(rows.len() as u32 - 1);
+    Size::new(total_w.min(max.w), total_h.min(max.h))
+}
+
+pub(super) fn paint(
+    cols: &[Track],
+    rows: &[Track],
+    gap: (u32, u32),
+    pad: u32,
+    cells: &[(GridSpan, Node)],
+    rect: Rect,
+    canvas: &mut RgbaImage,
+) {
+    if cols.is_empty() || rows.is_empty() {
+        return;
+    }
+    let inner_w = rect
+        .w
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.0.saturating_mul(cols.len().saturating_sub(1) as u32));
+    let inner_h = rect
+        .h
+        .saturating_sub(pad * 2)
+        .saturating_sub(gap.1.saturating_mul(rows.len().saturating_sub(1) as u32));
+    let col_widths = solve_tracks(cols, inner_w, |c| {
+        max_natural_in_track(cells, c, true, gap, rect.size())
+    });
+    let row_heights = solve_tracks(rows, inner_h, |r| {
+        max_natural_in_track(cells, r, false, gap, rect.size())
+    });
+
+    // Cumulative track offsets — col_off[i] is the start of column i
+    // (after preceding gaps); col_off[cols.len()] is the end of the
+    // last column with no trailing gap.
+    let mut col_off = vec![0u32; cols.len() + 1];
+    for i in 0..cols.len() {
+        col_off[i + 1] = col_off[i] + col_widths[i] + if i + 1 < cols.len() { gap.0 } else { 0 };
+    }
+    let mut row_off = vec![0u32; rows.len() + 1];
+    for i in 0..rows.len() {
+        row_off[i + 1] = row_off[i] + row_heights[i] + if i + 1 < rows.len() { gap.1 } else { 0 };
+    }
+
+    let n_cells = safety::cap_cells(cells.len());
+    for (span, child) in cells.iter().take(n_cells) {
+        if span.col >= cols.len() as u32 || span.row >= rows.len() as u32 {
+            continue;
+        }
+        let cs = span.cs().min(cols.len() as u32 - span.col);
+        let rs = span.rs().min(rows.len() as u32 - span.row);
+        let end_col = (span.col + cs) as usize;
+        let end_row = (span.row + rs) as usize;
+        // Subtract trailing gap only when ending mid-grid.
+        let x_end = if end_col < cols.len() {
+            col_off[end_col].saturating_sub(gap.0)
+        } else {
+            col_off[end_col]
+        };
+        let y_end = if end_row < rows.len() {
+            row_off[end_row].saturating_sub(gap.1)
+        } else {
+            row_off[end_row]
+        };
+        let x0 = rect.x + pad + col_off[span.col as usize];
+        let y0 = rect.y + pad + row_off[span.row as usize];
+        let x1 = rect.x + pad + x_end;
+        let y1 = rect.y + pad + y_end;
+        let w = x1.saturating_sub(x0);
+        let h = y1.saturating_sub(y0);
+        child.paint(Rect::new(x0, y0, w, h), canvas);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::color::BLACK;
+    use super::super::modifiers::LayoutMod;
+    use super::super::node::{empty, image as image_node};
+    use super::*;
+    use image::{Rgba, RgbaImage};
+
+    fn solid(w: u32, h: u32, c: super::super::color::Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    #[test]
+    fn grid_uniform_fr_fills_constraint() {
+        let img = grid()
+            .cols(2)
+            .equal_rows(2)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 255, 0, 255]).fill())
+            .cell(0, 1, empty().background([0, 0, 255, 255]).fill())
+            .cell(1, 1, empty().background([255, 255, 0, 255]).fill())
+            .size(80, 80)
+            .render(80);
+        assert_eq!(img.get_pixel(20, 20), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(60, 20), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(20, 60), &Rgba([0, 0, 255, 255]));
+        assert_eq!(img.get_pixel(60, 60), &Rgba([255, 255, 0, 255]));
+    }
+
+    #[test]
+    fn grid_track_px_takes_fixed_size() {
+        let img = grid()
+            .columns([Track::Px(20), Track::Fr(1)])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(100, 10)
+            .render(100);
+        assert_eq!(img.get_pixel(10, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grid_track_auto_hugs_content() {
+        let img = grid()
+            .columns([Track::Auto, Track::Fr(1)])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, image_node(solid(15, 10, [255, 0, 0, 255])))
+            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(100, 10)
+            .render(100);
+        assert_eq!(img.get_pixel(7, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn frmin_guarantees_minimum_when_remainder_collapses() {
+        // [Auto(80), FrMin(1, 10), Auto(80)] in 100 px → FrMin's
+        // proportional share = 0 (no remainder), so it must clamp to
+        // its 10-px minimum. Total width = 80 + 10 + 80 = 170 (overflow,
+        // but FrMin held its minimum).
+        let img = grid()
+            .columns([
+                Track::Px(80),
+                Track::FrMin {
+                    weight: 1,
+                    min_px: 10,
+                },
+                Track::Px(80),
+            ])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 255, 0, 255]).fill())
+            .cell(2, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(200, 10)
+            .render(200);
+        // Track positions: red 0..80, green 80..90, blue 90..170.
+        // Even though we asked for 100 of available, FrMin took its
+        // 10 anyway and pushed blue past col 1's natural end.
+        assert_eq!(img.get_pixel(40, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(85, 5), &Rgba([0, 255, 0, 255])); // FrMin's min
+        assert_eq!(img.get_pixel(120, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn auto_tracks_shrink_proportionally_under_overflow() {
+        // [Auto(60), FrMin(1, 6), Auto(120)] in 100 px.
+        // Sum non-Fr = 180; budget after FrMin's 6 px min = 94.
+        // Auto pair shrinks to 94 px split 60:120 → ~31:63.
+        let img = grid()
+            .columns([
+                Track::Auto,
+                Track::FrMin {
+                    weight: 1,
+                    min_px: 6,
+                },
+                Track::Auto,
+            ])
+            .equal_rows(1)
+            .gap(0)
+            .cell(
+                0,
+                0,
+                empty().background([255, 0, 0, 255]).fill().size(60, 10),
+            )
+            .cell(1, 0, empty().background([0, 255, 0, 255]).fill())
+            .cell(
+                2,
+                0,
+                empty().background([0, 0, 255, 255]).fill().size(120, 10),
+            )
+            .size(100, 10)
+            .render(100);
+        // Total within available (100). Right cell (blue) ends at x=99.
+        assert_eq!(img.get_pixel(99, 5), &Rgba([0, 0, 255, 255]));
+        // Far-left red, far-right blue, with green strip somewhere in between.
+        assert_eq!(img.get_pixel(0, 5), &Rgba([255, 0, 0, 255]));
+    }
+
+    #[test]
+    fn frmin_distributes_remainder_when_above_min() {
+        // [Auto(40), FrMin(1, 6), Auto(40)] in 100 px → remainder 20
+        // > min 6, so FrMin gets the full 20.
+        let img = grid()
+            .columns([
+                Track::Px(40),
+                Track::FrMin {
+                    weight: 1,
+                    min_px: 6,
+                },
+                Track::Px(40),
+            ])
+            .equal_rows(1)
+            .gap(0)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 255, 0, 255]).fill())
+            .cell(2, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(100, 10)
+            .render(100);
+        // Red 0..40, green 40..60, blue 60..100.
+        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 255, 0, 255])); // FrMin = 20
+        assert_eq!(img.get_pixel(80, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grid_with_gap_last_col_full_width() {
+        // Regression: the last column was being clipped by gap (off-by-pad bug).
+        // 2 cols of Px(20), gap 8, padding 8 → total 8 + 20 + 8 + 20 + 8 = 64.
+        let img = grid()
+            .columns([Track::Px(20), Track::Px(20)])
+            .equal_rows(1)
+            .gap(8)
+            .padding(8)
+            .cell(0, 0, empty().background([255, 0, 0, 255]).fill())
+            .cell(1, 0, empty().background([0, 0, 255, 255]).fill())
+            .size(64, 36)
+            .render(64);
+        assert_eq!(img.get_pixel(8, 18), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(27, 18), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(36, 18), &Rgba([0, 0, 255, 255]));
+        assert_eq!(img.get_pixel(55, 18), &Rgba([0, 0, 255, 255]));
+        assert_eq!(img.get_pixel(56, 18), &Rgba(BLACK));
+    }
+
+    #[test]
+    fn grid_areas_parses_template() {
+        let img = grid()
+            .areas(&["title title", "exp   act"])
+            .row_heights([Track::Px(10), Track::Px(20)])
+            .gap(0)
+            .place("title", empty().background([255, 0, 0, 255]).fill())
+            .place("exp", empty().background([0, 255, 0, 255]).fill())
+            .place("act", empty().background([0, 0, 255, 255]).fill())
+            .size(40, 30)
+            .render(40);
+        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(10, 20), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(30, 20), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grid_span_via_areas() {
+        let img = grid()
+            .areas(&["banner banner", "a a"])
+            .equal_rows(2)
+            .gap(0)
+            .place("banner", empty().background([0, 255, 0, 255]).fill())
+            .place("a", empty().background([255, 0, 0, 255]).fill())
+            .size(40, 40)
+            .render(40);
+        assert_eq!(img.get_pixel(10, 10), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(30, 10), &Rgba([0, 255, 0, 255]));
+        assert_eq!(img.get_pixel(20, 30), &Rgba([255, 0, 0, 255]));
+    }
+}

--- a/zensim-regress/src/layout/label.rs
+++ b/zensim-regress/src/layout/label.rs
@@ -1,0 +1,712 @@
+//! Label strips — the pervasive "background-filled bar with centered
+//! text" pattern used in diff montages. Two flavors:
+//!
+//! - [`LabelStyle::strip`] — single text, horizontally aligned per
+//!   `LabelStyle::align`, vertically centered.
+//! - [`LabelStyle::segmented_strip`] — multiple [`LabelSegment`]s,
+//!   each aligned independently within the same strip via [`Layers`].
+
+use image::RgbaImage;
+
+use super::color::{Color, rgb};
+use super::geom::{HAlign, Insets, Rect, Size, VAlign};
+use super::modifiers::{LayoutMod, wrap_padded};
+use super::node::{Node, fill, text};
+use super::paint::{fill_rect, render_image};
+use super::sizing::Fit;
+use super::text::TextSpec;
+use crate::font;
+
+#[derive(Clone, Debug)]
+pub struct LabelStyle {
+    pub fg: Color,
+    pub bg: Color,
+    pub align: HAlign,
+    pub padding: Insets,
+    /// `None` → auto-fit width via `font::measure_lines_fitted`.
+    pub char_h: Option<u32>,
+}
+
+impl Default for LabelStyle {
+    fn default() -> Self {
+        Self {
+            fg: rgb(220, 220, 220),
+            bg: rgb(40, 40, 40),
+            align: HAlign::Center,
+            padding: Insets::xy(8, 2),
+            char_h: None,
+        }
+    }
+}
+
+impl LabelStyle {
+    pub fn with_fg(mut self, fg: Color) -> Self {
+        self.fg = fg;
+        self
+    }
+    pub fn with_bg(mut self, bg: Color) -> Self {
+        self.bg = bg;
+        self
+    }
+    pub fn with_align(mut self, align: HAlign) -> Self {
+        self.align = align;
+        self
+    }
+    pub fn with_padding(mut self, padding: Insets) -> Self {
+        self.padding = padding;
+        self
+    }
+    pub fn with_char_h(mut self, char_h: u32) -> Self {
+        self.char_h = Some(char_h);
+        self
+    }
+
+    /// Build a single-text label strip — `fill_width` background-filled
+    /// box with vertically-centered, horizontally-aligned-per-style text.
+    pub fn strip(&self, s: impl Into<String>) -> Node {
+        let inner = match self.char_h {
+            Some(h) => text(TextSpec::fixed(s, self.fg, self.bg, h)),
+            None => text(TextSpec::lines(vec![(s.into(), self.fg)], self.bg)),
+        };
+        let mut inner: Node = inner.align(self.align, VAlign::Center);
+        if self.padding != Insets::default() {
+            inner = wrap_padded(inner, self.padding);
+        }
+        inner.background(self.bg).fill_width()
+    }
+
+    /// Build a width-aware segmented label strip — left/center/right
+    /// groups sized so they always fit side-by-side at any reasonable
+    /// strip width, with a guaranteed minimum gap between groups.
+    ///
+    /// At paint time, the variant computes a single `char_h` from the
+    /// actual rect width such that:
+    ///
+    /// 1. Total content width + min-gaps ≤ inner strip width.
+    /// 2. `char_h` is as large as possible (preferring readability).
+    /// 3. `char_h` ≤ `style.char_h` if explicitly set (caller's cap).
+    /// 4. `char_h` ≤ inner strip height (so glyphs never extend
+    ///    above/below the strip).
+    /// 5. `char_h` ≥ `font::GLYPH_H / 4` (legibility floor).
+    ///
+    /// This avoids both "labels too small at narrow strips" (the old
+    /// fixed `GLYPH_H/2` default) and "labels overflow strip" (when
+    /// caller forces too large a `char_h`).
+    pub fn segmented_strip(&self, segments: Vec<LabelSegment>) -> Node {
+        if segments.is_empty() {
+            return fill(self.bg);
+        }
+        // Wrap in fill_width so the strip always spans its container's
+        // cross axis (matching the old grid-based implementation).
+        // Without this, a hug-cross stack would size the strip to its
+        // natural content width and leave canvas_bg showing through
+        // around it.
+        Node::SegmentedStrip {
+            segments,
+            style: Box::new(self.clone()),
+        }
+        .fill_width()
+    }
+}
+
+// ── SegmentedStrip measure / paint ──────────────────────────────────────
+
+/// Pixel gap between adjacent groups, used both to space left+right
+/// when both are present and as a guard inside groups.
+pub(super) const SEGMENT_INTER_GROUP_GAP: u32 = 6;
+/// Pixel gap between segments inside the same group.
+pub(super) const SEGMENT_INTRA_GROUP_GAP: u32 = 2;
+
+/// Total character count across all segments — used to invert the
+/// `char_w(h) = round(BASE_W × h / BASE_H)` formula and pick the
+/// largest `h` that fits.
+fn total_chars(segments: &[LabelSegment]) -> u32 {
+    segments.iter().map(|s| s.text.chars().count() as u32).sum()
+}
+
+/// Number of non-empty (left, center, right) groups in `segments`.
+fn group_count(segments: &[LabelSegment]) -> u32 {
+    let mut l = false;
+    let mut c = false;
+    let mut r = false;
+    for s in segments {
+        match s.align {
+            HAlign::Left => l = true,
+            HAlign::Center => c = true,
+            HAlign::Right => r = true,
+        }
+    }
+    [l, c, r].iter().filter(|x| **x).count() as u32
+}
+
+/// Pick the largest `char_h` such that all segments fit side-by-side
+/// in `inner_w` × `inner_h`. The result is bounded by
+/// `style.char_h` (if set), `inner_h`, [`font::GLYPH_H`] (no upscaling
+/// past the embedded strip's native height), and a legibility floor
+/// of `font::GLYPH_H / 4`.
+pub(super) fn fit_segmented_char_h(
+    segments: &[LabelSegment],
+    style: &LabelStyle,
+    inner_w: u32,
+    inner_h: u32,
+) -> u32 {
+    let total = total_chars(segments).max(1);
+    let groups = group_count(segments);
+    let intra: u32 = segments
+        .iter()
+        .fold(([0u32; 3], 0u32), |(mut counts, _), s| {
+            let i = match s.align {
+                HAlign::Left => 0,
+                HAlign::Center => 1,
+                HAlign::Right => 2,
+            };
+            counts[i] += 1;
+            (counts, 0)
+        })
+        .0
+        .iter()
+        .map(|n| SEGMENT_INTRA_GROUP_GAP * n.saturating_sub(1))
+        .sum();
+    let inter = SEGMENT_INTER_GROUP_GAP * groups.saturating_sub(1);
+    let glyph_budget = inner_w.saturating_sub(intra + inter);
+    // char_w(h) ≈ BASE_W × h / BASE_H.
+    // total × char_w(h) ≤ glyph_budget
+    // h ≤ glyph_budget × BASE_H / (total × BASE_W)
+    let max_h_by_width = ((glyph_budget as u64) * (font::GLYPH_H as u64)
+        / ((total as u64) * (font::GLYPH_W as u64))) as u32;
+    // When the caller explicitly sets `style.char_h`, respect their
+    // request (capped to inner_h and max_h_by_width to prevent
+    // overflow but NOT to font::GLYPH_H — the rasterizer will upscale
+    // if a larger char_h was requested).
+    //
+    // When auto-fitting (`char_h is None`), cap at font::GLYPH_H to
+    // avoid blurry upscale and at max_h_by_width so content fits.
+    let max_h = match style.char_h {
+        Some(h) => h.min(inner_h).min(max_h_by_width),
+        None => font::GLYPH_H.min(inner_h).min(max_h_by_width),
+    };
+    max_h.max(font::GLYPH_H / 4)
+}
+
+/// Approximate scaled-character width at `char_h` — mirrors
+/// [`font::char_width_for_height`] (which is private). Off by ≤ 1 px.
+fn approx_char_w(char_h: u32) -> u32 {
+    (font::GLYPH_W * char_h + font::GLYPH_H / 2) / font::GLYPH_H
+}
+
+/// Measure pass — width hugs `max.w` if [`SizeRule::Fill`] is wrapping
+/// us, else the natural content width at `style.char_h.unwrap_or(GLYPH_H/2)`.
+/// Height = char_h + padding (so a SegmentedStrip placed inside a
+/// hug-content stack still gets a reasonable height).
+pub(super) fn measure_segmented_strip(
+    segments: &[LabelSegment],
+    style: &LabelStyle,
+    max: Size,
+) -> Size {
+    let inner_w = max.w.saturating_sub(style.padding.horizontal());
+    let inner_h = max.h.saturating_sub(style.padding.vertical());
+    let char_h = fit_segmented_char_h(segments, style, inner_w, inner_h);
+    let total_w = approx_char_w(char_h).saturating_mul(total_chars(segments).max(1));
+    let groups = group_count(segments);
+    let intra: u32 = segments
+        .iter()
+        .fold([0u32; 3], |mut counts, s| {
+            let i = match s.align {
+                HAlign::Left => 0,
+                HAlign::Center => 1,
+                HAlign::Right => 2,
+            };
+            counts[i] += 1;
+            counts
+        })
+        .iter()
+        .map(|n| SEGMENT_INTRA_GROUP_GAP * n.saturating_sub(1))
+        .sum();
+    let inter = SEGMENT_INTER_GROUP_GAP * groups.saturating_sub(1);
+    let natural_w = total_w + intra + inter + style.padding.horizontal();
+    let h = char_h + style.padding.vertical();
+    Size::new(natural_w.min(max.w), h.min(max.h))
+}
+
+/// Paint pass — uses the actual rect to compute a width-fit `char_h`,
+/// then rasterizes each segment and lays them out left/center/right
+/// with the inter- and intra-group gaps.
+pub(super) fn paint_segmented_strip(
+    segments: &[LabelSegment],
+    style: &LabelStyle,
+    rect: Rect,
+    canvas: &mut RgbaImage,
+) {
+    fill_rect(canvas, rect, style.bg);
+
+    if segments.is_empty() {
+        return;
+    }
+    let inner = Rect::new(
+        rect.x.saturating_add(style.padding.left),
+        rect.y.saturating_add(style.padding.top),
+        rect.w.saturating_sub(style.padding.horizontal()),
+        rect.h.saturating_sub(style.padding.vertical()),
+    );
+    if inner.w == 0 || inner.h == 0 {
+        return;
+    }
+
+    let char_h = fit_segmented_char_h(segments, style, inner.w, inner.h);
+    if char_h == 0 {
+        return;
+    }
+
+    // Rasterize each segment once so we have actual widths.
+    let mut rasters: Vec<(LabelSegment, RgbaImage)> = Vec::with_capacity(segments.len());
+    for seg in segments {
+        // Per-segment char_h overrides take precedence; cap at the
+        // shared char_h derived from the strip's geometry so all
+        // segments share a baseline. Don't cap at GLYPH_H — caller's
+        // explicit char_h is honored even if it requires upscale.
+        let h = seg.char_h.unwrap_or(char_h).min(inner.h);
+        let (buf, w, glyph_h) = font::render_text_height(&seg.text, seg.fg, style.bg, h);
+        if w == 0 || glyph_h == 0 {
+            continue;
+        }
+        let Some(img) = RgbaImage::from_raw(w, glyph_h, buf) else {
+            continue;
+        };
+        rasters.push((seg.clone(), img));
+    }
+
+    // Group widths.
+    let mut widths = [0u32; 3];
+    let mut group_segs: [Vec<usize>; 3] = [Vec::new(), Vec::new(), Vec::new()];
+    for (i, (seg, img)) in rasters.iter().enumerate() {
+        let g = match seg.align {
+            HAlign::Left => 0,
+            HAlign::Center => 1,
+            HAlign::Right => 2,
+        };
+        group_segs[g].push(i);
+        if !group_segs[g].is_empty() && widths[g] > 0 {
+            widths[g] += SEGMENT_INTRA_GROUP_GAP;
+        }
+        widths[g] += img.width();
+    }
+
+    // Place each group within `inner`.
+    let typo_shift = ((char_h as f32) * font::TYPO_CAP_MID_OFFSET).round() as u32;
+    let baseline_y = inner.y + (inner.h.saturating_sub(char_h)) / 2 + typo_shift;
+
+    let place_group = |g: usize, x_start: u32, canvas: &mut RgbaImage| {
+        let mut x = x_start;
+        let mut first = true;
+        for &i in &group_segs[g] {
+            let (_seg, img) = &rasters[i];
+            if !first {
+                x += SEGMENT_INTRA_GROUP_GAP;
+            }
+            first = false;
+            render_image(
+                img,
+                Fit::None,
+                Rect::new(x, baseline_y, img.width(), img.height()),
+                canvas,
+            );
+            x += img.width();
+        }
+    };
+
+    // Left group hugs the left edge.
+    if !group_segs[0].is_empty() {
+        place_group(0, inner.x, canvas);
+    }
+    // Right group hugs the right edge.
+    if !group_segs[2].is_empty() {
+        let x = inner.x.saturating_add(inner.w).saturating_sub(widths[2]);
+        place_group(2, x, canvas);
+    }
+    // Center group centers in remaining space (between left's end and
+    // right's start, with min inter-group gaps preserved).
+    if !group_segs[1].is_empty() {
+        let left_end = if group_segs[0].is_empty() {
+            inner.x
+        } else {
+            inner.x + widths[0] + SEGMENT_INTER_GROUP_GAP
+        };
+        let right_start = if group_segs[2].is_empty() {
+            inner.x + inner.w
+        } else {
+            inner.x + inner.w - widths[2] - SEGMENT_INTER_GROUP_GAP
+        };
+        let avail = right_start.saturating_sub(left_end);
+        let x_start = left_end + (avail.saturating_sub(widths[1])) / 2;
+        place_group(1, x_start, canvas);
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LabelSegment {
+    pub text: String,
+    pub fg: Color,
+    pub align: HAlign,
+    pub char_h: Option<u32>,
+}
+
+impl LabelSegment {
+    pub fn left(text: impl Into<String>, fg: Color) -> Self {
+        Self {
+            text: text.into(),
+            fg,
+            align: HAlign::Left,
+            char_h: None,
+        }
+    }
+    pub fn right(text: impl Into<String>, fg: Color) -> Self {
+        Self {
+            text: text.into(),
+            fg,
+            align: HAlign::Right,
+            char_h: None,
+        }
+    }
+    pub fn center(text: impl Into<String>, fg: Color) -> Self {
+        Self {
+            text: text.into(),
+            fg,
+            align: HAlign::Center,
+            char_h: None,
+        }
+    }
+    pub fn with_char_h(mut self, h: u32) -> Self {
+        self.char_h = Some(h);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::geom::Size;
+    use super::super::node::image as image_node;
+    use super::super::sizing::SizeRule;
+    use super::*;
+    use image::{Rgba, RgbaImage};
+
+    fn solid(w: u32, h: u32, c: Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    /// Helpers for SegmentedStrip pixel-level structural tests. Render
+    /// a strip + return the canvas for inspection.
+    fn render_seg_strip(
+        segments: Vec<LabelSegment>,
+        style: &LabelStyle,
+        w: u32,
+        h: u32,
+    ) -> RgbaImage {
+        let n: Node = style
+            .segmented_strip(segments)
+            .width(SizeRule::Fixed(w))
+            .height(SizeRule::Fixed(h));
+        super::super::render(&n, w)
+    }
+
+    /// Find rightmost x at row `y` matching `is_target`.
+    fn rightmost_x(img: &RgbaImage, y: u32, is_target: impl Fn(&[u8; 4]) -> bool) -> Option<u32> {
+        (0..img.width())
+            .rev()
+            .find(|&x| is_target(&img.get_pixel(x, y).0))
+    }
+    fn leftmost_x(img: &RgbaImage, y: u32, is_target: impl Fn(&[u8; 4]) -> bool) -> Option<u32> {
+        (0..img.width()).find(|&x| is_target(&img.get_pixel(x, y).0))
+    }
+    fn is_orange(p: &[u8; 4]) -> bool {
+        p[0] > 200 && (140..200).contains(&p[1]) && p[2] < 130
+    }
+    fn is_cyan(p: &[u8; 4]) -> bool {
+        p[0] < 130 && p[1] > 180 && p[2] > 180
+    }
+
+    #[test]
+    fn label_default_strip_above_image() {
+        let img = image_node(solid(40, 40, [255, 0, 0, 255])).label("EXPECTED");
+        let s = img.measure(Size::new(400, 400));
+        assert!(s.h > 40);
+    }
+
+    #[test]
+    fn label_styled_uses_provided_bg() {
+        let style = LabelStyle::default()
+            .with_bg(rgb(100, 0, 0))
+            .with_fg(rgb(255, 255, 0));
+        let canvas = image_node(solid(40, 40, [255, 0, 0, 255]))
+            .label_styled("HELLO", &style)
+            .width(SizeRule::Fixed(40))
+            .render(40);
+        assert_eq!(canvas.get_pixel(0, 0), &Rgba([100, 0, 0, 255]));
+    }
+
+    #[test]
+    fn segmented_strip_renders_both_groups() {
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            240,
+            58,
+        );
+        // Both colors must appear somewhere in the strip.
+        let mut saw_orange = false;
+        let mut saw_cyan = false;
+        for y in 0..canvas.height() {
+            for x in 0..canvas.width() {
+                let p = canvas.get_pixel(x, y).0;
+                if is_orange(&p) {
+                    saw_orange = true;
+                }
+                if is_cyan(&p) {
+                    saw_cyan = true;
+                }
+            }
+        }
+        assert!(saw_orange, "ADD (orange) not rendered");
+        assert!(saw_cyan, "REMOVE (cyan) not rendered");
+    }
+
+    #[test]
+    fn segmented_strip_no_overflow_at_typical_width() {
+        // 240×58 strip. ADD/REMOVE must fit inside.
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            240,
+            58,
+        );
+        // Find rightmost cyan in the canvas. Must be < 240 (within strip).
+        let mid_y = canvas.height() / 2;
+        let right = (0..canvas.height())
+            .filter_map(|y| rightmost_x(&canvas, y, is_cyan))
+            .max();
+        if let Some(x) = right {
+            assert!(
+                x < 240,
+                "REMOVE rightmost pixel at x={} overflows 240-wide strip",
+                x
+            );
+            // Strip padding xy(8,2) → inner right at 240-8=232; allow small slop.
+            assert!(
+                x <= 232 + 1,
+                "REMOVE at x={} encroaches on right padding (mid_y={})",
+                x,
+                mid_y
+            );
+        } else {
+            panic!("no cyan pixels found at all");
+        }
+        // Same for ADD on the left.
+        let left = (0..canvas.height())
+            .filter_map(|y| leftmost_x(&canvas, y, is_orange))
+            .min();
+        if let Some(x) = left {
+            assert!(
+                x >= 8 - 1,
+                "ADD leftmost pixel at x={} overlaps left padding",
+                x
+            );
+        } else {
+            panic!("no orange pixels found");
+        }
+    }
+
+    #[test]
+    fn segmented_strip_no_overflow_at_narrow_width() {
+        // 80×30 strip — very tight. char_h must shrink so both segments fit.
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            80,
+            30,
+        );
+        let right = (0..canvas.height())
+            .filter_map(|y| rightmost_x(&canvas, y, is_cyan))
+            .max();
+        assert!(right.is_some(), "REMOVE not rendered at 80-wide strip");
+        let x = right.unwrap();
+        assert!(
+            x < 80,
+            "REMOVE rightmost pixel at x={} overflows 80-wide strip",
+            x
+        );
+    }
+
+    #[test]
+    fn segmented_strip_no_overflow_at_oversized_explicit_char_h() {
+        // Caller forces char_h=54 on 80-wide strip — segmented_strip
+        // must clamp char_h down to actually fit. Old implementation
+        // overflowed past the strip's right edge.
+        let style = LabelStyle::default().with_char_h(54);
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &style,
+            80,
+            30,
+        );
+        let right = (0..canvas.height())
+            .filter_map(|y| rightmost_x(&canvas, y, is_cyan))
+            .max();
+        assert!(right.is_some(), "REMOVE not rendered");
+        assert!(
+            right.unwrap() < 80,
+            "REMOVE at x={} overflows 80-wide strip with explicit char_h=54",
+            right.unwrap()
+        );
+    }
+
+    #[test]
+    fn segmented_strip_uses_large_char_h_when_room() {
+        // 400×60 strip with short ADD/REMOVE — char_h should approach
+        // GLYPH_H since there's plenty of room.
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("AB", rgb(255, 180, 80)),
+                LabelSegment::right("CD", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            400,
+            60,
+        );
+        // Measure orange glyph height — should be > 30 (more than half).
+        let orange_ys: Vec<u32> = (0..canvas.height())
+            .filter(|&y| (0..canvas.width()).any(|x| is_orange(&canvas.get_pixel(x, y).0)))
+            .collect();
+        assert!(!orange_ys.is_empty(), "no orange found");
+        let glyph_h = orange_ys.last().unwrap() - orange_ys.first().unwrap() + 1;
+        assert!(
+            glyph_h >= 24,
+            "char_h too small: glyph spans only {} rows in 60-tall strip with plenty of room",
+            glyph_h
+        );
+    }
+
+    #[test]
+    fn segmented_strip_min_gap_preserved() {
+        // 120×30 strip where ADD+REMOVE fit but barely. Inter-group
+        // gap should still be ≥ SEGMENT_INTER_GROUP_GAP.
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            120,
+            30,
+        );
+        // ADD's rightmost x and REMOVE's leftmost x at the row containing both.
+        for y in 0..canvas.height() {
+            let add_right = rightmost_x(&canvas, y, is_orange);
+            let rem_left = leftmost_x(&canvas, y, is_cyan);
+            if let (Some(ar), Some(rl)) = (add_right, rem_left) {
+                let gap = rl as i32 - ar as i32 - 1;
+                assert!(
+                    gap >= SEGMENT_INTER_GROUP_GAP as i32 - 2,
+                    "gap between ADD(x={}) and REMOVE(x={}) at y={} is {} < min {}",
+                    ar,
+                    rl,
+                    y,
+                    gap,
+                    SEGMENT_INTER_GROUP_GAP
+                );
+                return;
+            }
+        }
+        panic!("never found a row with both ADD and REMOVE");
+    }
+
+    #[test]
+    fn segmented_strip_left_at_left_edge() {
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            240,
+            58,
+        );
+        let left = (0..canvas.height())
+            .filter_map(|y| leftmost_x(&canvas, y, is_orange))
+            .min();
+        // ADD should start within ~2 px of the strip's left padding (8 px).
+        assert!(
+            (8..=12).contains(&left.unwrap()),
+            "ADD's leftmost pixel at x={} not near strip left padding",
+            left.unwrap()
+        );
+    }
+
+    #[test]
+    fn segmented_strip_right_at_right_edge() {
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            240,
+            58,
+        );
+        let right = (0..canvas.height())
+            .filter_map(|y| rightmost_x(&canvas, y, is_cyan))
+            .max();
+        // REMOVE's rightmost glyph pixel should be near (but ≤) the
+        // strip's right inner edge. char_w(h) is integer-rounded so the
+        // total content rarely fills the inner exactly — allow up to
+        // ~10 px of slack but never overflow.
+        let r = right.unwrap();
+        assert!(r < 240, "REMOVE at x={} overflows 240-wide strip", r);
+        assert!(
+            r >= 220,
+            "REMOVE at x={} sits too far from right edge (expected ≥ 220)",
+            r
+        );
+    }
+
+    #[test]
+    fn segmented_strip_vertical_centering() {
+        // Glyph mid-row should land near strip mid-row.
+        let canvas = render_seg_strip(
+            vec![
+                LabelSegment::left("ADD", rgb(255, 180, 80)),
+                LabelSegment::right("REMOVE", rgb(80, 220, 220)),
+            ],
+            &LabelStyle::default(),
+            240,
+            60,
+        );
+        let orange_ys: Vec<u32> = (0..canvas.height())
+            .filter(|&y| (0..canvas.width()).any(|x| is_orange(&canvas.get_pixel(x, y).0)))
+            .collect();
+        let glyph_top = *orange_ys.first().unwrap();
+        let glyph_bot = *orange_ys.last().unwrap();
+        let glyph_mid = (glyph_top + glyph_bot) / 2;
+        let strip_mid = canvas.height() / 2;
+        let drift = (glyph_mid as i32 - strip_mid as i32).abs();
+        // Glyph mid should be within ~1/8 of strip height of strip mid
+        // (typographic shift accounts for glyph cell whitespace).
+        assert!(
+            drift <= (canvas.height() / 8) as i32,
+            "glyph mid y={} drifts {} px from strip mid {}",
+            glyph_mid,
+            drift,
+            strip_mid
+        );
+    }
+}

--- a/zensim-regress/src/layout/layers.rs
+++ b/zensim-regress/src/layout/layers.rs
@@ -1,0 +1,93 @@
+//! Z-stack container — children render at the same rect in painter's
+//! order. Roughly CSS `position: absolute` siblings.
+
+use image::RgbaImage;
+
+use super::geom::{Rect, Size};
+use super::node::Node;
+use super::safety;
+
+#[derive(Clone, Debug, Default)]
+pub struct Layers {
+    children: Vec<Node>,
+}
+
+impl Layers {
+    pub fn new() -> Self {
+        Self::default()
+    }
+    pub fn child(mut self, c: impl Into<Node>) -> Self {
+        self.children.push(c.into());
+        self
+    }
+    pub fn children<I, N>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = N>,
+        N: Into<Node>,
+    {
+        self.children.extend(items.into_iter().map(Into::into));
+        self
+    }
+}
+
+/// Free-fn entry point for an empty [`Layers`] builder.
+pub fn layers() -> Layers {
+    Layers::new()
+}
+
+impl From<Layers> for Node {
+    fn from(l: Layers) -> Node {
+        Node::Layers(l.children)
+    }
+}
+
+pub(super) fn measure(children: &[Node], max: Size) -> Size {
+    let n = safety::cap_children(children.len());
+    let mut out = Size::ZERO;
+    for c in children.iter().take(n) {
+        let s = c.measure(max);
+        out.w = out.w.max(s.w);
+        out.h = out.h.max(s.h);
+    }
+    out
+}
+
+pub(super) fn paint(children: &[Node], rect: Rect, canvas: &mut RgbaImage) {
+    let n = safety::cap_children(children.len());
+    for c in children.iter().take(n) {
+        c.paint(rect, canvas);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::color::WHITE;
+    use super::super::modifiers::LayoutMod;
+    use super::super::node::{empty, image as image_node};
+    use super::*;
+    use image::{Rgba, RgbaImage};
+
+    fn solid(w: u32, h: u32, c: super::super::color::Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    #[test]
+    fn layers_max_size() {
+        let a = image_node(solid(50, 30, WHITE));
+        let b = image_node(solid(20, 80, WHITE));
+        let l = layers().child(a).child(b);
+        assert_eq!(
+            Node::from(l).measure(Size::new(200, 200)),
+            Size::new(50, 80)
+        );
+    }
+
+    #[test]
+    fn layers_painters_order() {
+        let bg = empty().background([255, 0, 0, 255]).fill();
+        let dot = image_node(solid(4, 4, [0, 255, 0, 255])).center();
+        let img = layers().child(bg).child(dot).size(20, 20).render(20);
+        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(10, 10), &Rgba([0, 255, 0, 255]));
+    }
+}

--- a/zensim-regress/src/layout/modifiers.rs
+++ b/zensim-regress/src/layout/modifiers.rs
@@ -1,0 +1,463 @@
+//! Modifier nodes — `Padded` / `Sized` / `Constrain` / `Aspect` /
+//! `Align` / `Fit` / `Background` / `Border` — together with the
+//! [`LayoutMod`] trait that gives every node and builder fluent
+//! modifier methods (`.padding(8)`, `.center()`, `.background(c)`, ...).
+
+use image::RgbaImage;
+
+use super::color::Color;
+use super::geom::{HAlign, Insets, Rect, Size, VAlign};
+use super::label::{LabelSegment, LabelStyle};
+use super::node::Node;
+use super::paint;
+use super::safety;
+use super::sizing::{Fit, SizeRule};
+
+// ── Wrap helpers ───────────────────────────────────────────────────────
+
+pub(super) fn wrap_padded(child: Node, insets: Insets) -> Node {
+    Node::Padded {
+        insets,
+        child: Box::new(child),
+    }
+}
+pub(super) fn wrap_sized(child: Node, w: SizeRule, h: SizeRule) -> Node {
+    Node::Sized {
+        w,
+        h,
+        child: Box::new(child),
+    }
+}
+pub(super) fn wrap_constrain(
+    child: Node,
+    min_w: Option<u32>,
+    max_w: Option<u32>,
+    min_h: Option<u32>,
+    max_h: Option<u32>,
+) -> Node {
+    Node::Constrain {
+        min_w,
+        max_w,
+        min_h,
+        max_h,
+        child: Box::new(child),
+    }
+}
+
+// ── Per-modifier measure helpers ──────────────────────────────────────
+
+pub(super) fn measure_padded(insets: Insets, child: &Node, max: Size) -> Size {
+    let inner_max = Size::new(
+        max.w.saturating_sub(insets.horizontal()),
+        max.h.saturating_sub(insets.vertical()),
+    );
+    let inner = child.measure(inner_max);
+    Size::new(inner.w + insets.horizontal(), inner.h + insets.vertical())
+}
+
+pub(super) fn measure_sized(w: SizeRule, h: SizeRule, child: &Node, max: Size) -> Size {
+    let child_size = child.measure(max);
+    let resolve = |rule: SizeRule, axis_max: u32, child_dim: u32| -> u32 {
+        match rule {
+            SizeRule::Hug => child_dim,
+            // Fill / Grow inside an unbounded constraint would otherwise
+            // happily stretch to u32::MAX; clamp to MAX_DIM.
+            SizeRule::Fill | SizeRule::Grow(_) => safety::clamp_dim(axis_max),
+            SizeRule::Fixed(v) => safety::clamp_dim(v),
+            SizeRule::Percent(p) => {
+                if axis_max == 0 || p.is_nan() {
+                    0
+                } else {
+                    let v = ((axis_max as f32) * p.clamp(0.0, 1.0)).round() as u32;
+                    safety::clamp_dim(v)
+                }
+            }
+        }
+    };
+    Size::new(
+        resolve(w, max.w, child_size.w),
+        resolve(h, max.h, child_size.h),
+    )
+}
+
+pub(super) fn measure_constrain(
+    min_w: Option<u32>,
+    max_w: Option<u32>,
+    min_h: Option<u32>,
+    max_h: Option<u32>,
+    child: &Node,
+    max: Size,
+) -> Size {
+    let cap_max_w = max_w.map(safety::clamp_dim);
+    let cap_max_h = max_h.map(safety::clamp_dim);
+    let cap_min_w = min_w.map(safety::clamp_dim);
+    let cap_min_h = min_h.map(safety::clamp_dim);
+    let child_max = Size::new(
+        cap_max_w.map_or(max.w, |v| v.min(max.w)),
+        cap_max_h.map_or(max.h, |v| v.min(max.h)),
+    );
+    let s = child.measure(child_max);
+    safety::clamp_size(Size::new(
+        s.w.max(cap_min_w.unwrap_or(0))
+            .min(cap_max_w.unwrap_or(u32::MAX))
+            .min(max.w),
+        s.h.max(cap_min_h.unwrap_or(0))
+            .min(cap_max_h.unwrap_or(u32::MAX))
+            .min(max.h),
+    ))
+}
+
+pub(super) fn measure_aspect(num: u32, den: u32, child: &Node, max: Size) -> Size {
+    let s = child.measure(max);
+    let cw = s.w.max(1);
+    let ch = s.h.max(1);
+    let h_from_w = cw * den / num;
+    let w_from_h = ch * num / den;
+    if h_from_w <= max.h && cw <= max.w && h_from_w >= ch {
+        Size::new(cw, h_from_w)
+    } else if w_from_h <= max.w && ch <= max.h {
+        Size::new(w_from_h, ch)
+    } else {
+        // Both candidates exceed; scale to fit max while preserving ratio.
+        let h_from_max_w = max.w * den / num;
+        if h_from_max_w <= max.h {
+            Size::new(max.w, h_from_max_w)
+        } else {
+            Size::new(max.h * num / den, max.h)
+        }
+    }
+}
+
+// ── Per-modifier paint helpers ────────────────────────────────────────
+
+pub(super) fn paint_padded(insets: Insets, child: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    let inner = Rect::new(
+        rect.x.saturating_add(insets.left),
+        rect.y.saturating_add(insets.top),
+        rect.w.saturating_sub(insets.horizontal()),
+        rect.h.saturating_sub(insets.vertical()),
+    );
+    child.paint(inner, canvas);
+}
+
+pub(super) fn paint_align(h: HAlign, v: VAlign, child: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    let child_size = child.measure(rect.size());
+    let x_off = match h {
+        HAlign::Left => 0,
+        HAlign::Center => rect.w.saturating_sub(child_size.w) / 2,
+        HAlign::Right => rect.w.saturating_sub(child_size.w),
+    };
+    let mut y_off = match v {
+        VAlign::Top => 0,
+        VAlign::Center => rect.h.saturating_sub(child_size.h) / 2,
+        VAlign::Bottom => rect.h.saturating_sub(child_size.h),
+    };
+    // Typographic centering: when vertically centering a text-bearing
+    // child, shift it down by `font::TYPO_CAP_MID_OFFSET` of its
+    // height so the inked cap-mid (~42.6% of cell) lands at the box
+    // geometric mid. Without this, capitals visibly skew above center
+    // because the embedded glyph cell has whitespace above cap-top.
+    if matches!(v, VAlign::Center) && contains_text(child) {
+        let typo_shift = ((child_size.h as f32) * crate::font::TYPO_CAP_MID_OFFSET).round() as u32;
+        y_off = y_off.saturating_add(typo_shift);
+    }
+    let inner = Rect::new(
+        rect.x.saturating_add(x_off),
+        rect.y.saturating_add(y_off),
+        child_size.w.min(rect.w),
+        child_size.h.min(rect.h),
+    );
+    child.paint(inner, canvas);
+}
+
+/// `true` if `node` reaches a [`Node::Text`] leaf via pass-through
+/// modifier wrappers (Padded, Sized, Constrain, Aspect, Background,
+/// Border, Fit). Stops at `Align` (don't double-apply) and at
+/// containers (Stack/Grid/Layers — those manage their own children).
+fn contains_text(node: &Node) -> bool {
+    match node {
+        Node::Text(_) => true,
+        Node::Padded { child, .. }
+        | Node::Sized { child, .. }
+        | Node::Constrain { child, .. }
+        | Node::Aspect { child, .. }
+        | Node::Background { child, .. }
+        | Node::Border { child, .. }
+        | Node::Fit { child, .. } => contains_text(child),
+        _ => false,
+    }
+}
+
+pub(super) fn paint_fit(mode: Fit, child: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    if let Node::Image(img) = child {
+        paint::render_image(img, mode, rect, canvas);
+    } else {
+        child.paint(rect, canvas);
+    }
+}
+
+pub(super) fn paint_background(color: Color, child: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    paint::fill_rect(canvas, rect, color);
+    child.paint(rect, canvas);
+}
+
+pub(super) fn paint_border(color: Color, child: &Node, rect: Rect, canvas: &mut RgbaImage) {
+    child.paint(rect, canvas);
+    paint::draw_rect_border(canvas, rect, color);
+}
+
+// ── LayoutMod trait — fluent modifier methods ─────────────────────────
+
+/// Modifier methods on any layout node or builder. Auto-imported via
+/// `use zensim_regress::layout::*;`.
+pub trait LayoutMod: Sized {
+    fn into_node(self) -> Node;
+
+    // ── Padding (CSS `padding`) ────────────────────────────────────────
+    fn padding(self, v: u32) -> Node {
+        wrap_padded(self.into_node(), Insets::all(v))
+    }
+    fn padding_xy(self, x: u32, y: u32) -> Node {
+        wrap_padded(self.into_node(), Insets::xy(x, y))
+    }
+    /// CSS shorthand order: top, right, bottom, left.
+    fn padding_each(self, t: u32, r: u32, b: u32, l: u32) -> Node {
+        wrap_padded(self.into_node(), Insets::each(t, r, b, l))
+    }
+
+    // ── Sizing (CSS `width`, `height`) ────────────────────────────────
+    fn width(self, r: SizeRule) -> Node {
+        wrap_sized(self.into_node(), r, SizeRule::Hug)
+    }
+    fn height(self, r: SizeRule) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Hug, r)
+    }
+    fn size(self, w: u32, h: u32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Fixed(w), SizeRule::Fixed(h))
+    }
+    fn fill_width(self) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Fill, SizeRule::Hug)
+    }
+    fn fill_height(self) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Hug, SizeRule::Fill)
+    }
+    fn fill(self) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Fill, SizeRule::Fill)
+    }
+    /// Weighted main-axis grow — CSS `flex-grow`.
+    fn grow(self, weight: u32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Grow(weight), SizeRule::Hug)
+    }
+
+    /// Width as a fraction of the parent constraint, `[0.0, 1.0]`
+    /// (CSS `width: 50%` = `width_percent(0.5)`).
+    fn width_percent(self, p: f32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Percent(p), SizeRule::Hug)
+    }
+    /// Height as a fraction of the parent constraint.
+    fn height_percent(self, p: f32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Hug, SizeRule::Percent(p))
+    }
+    /// `(width%, height%)` of the parent constraint.
+    fn size_percent(self, w: f32, h: f32) -> Node {
+        wrap_sized(self.into_node(), SizeRule::Percent(w), SizeRule::Percent(h))
+    }
+
+    // ── Min/Max constraints (CSS `min-width` etc.) ────────────────────
+    fn min_width(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), Some(n), None, None, None)
+    }
+    fn max_width(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), None, Some(n), None, None)
+    }
+    fn min_height(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), None, None, Some(n), None)
+    }
+    fn max_height(self, n: u32) -> Node {
+        wrap_constrain(self.into_node(), None, None, None, Some(n))
+    }
+
+    /// CSS `aspect-ratio: <num> / <den>`.
+    fn aspect_ratio(self, num: u32, den: u32) -> Node {
+        Node::Aspect {
+            num: num.max(1),
+            den: den.max(1),
+            child: Box::new(self.into_node()),
+        }
+    }
+
+    // ── Alignment (CSS `place-self`) ──────────────────────────────────
+    fn align(self, h: HAlign, v: VAlign) -> Node {
+        Node::Align {
+            h,
+            v,
+            child: Box::new(self.into_node()),
+        }
+    }
+    fn center(self) -> Node {
+        self.align(HAlign::Center, VAlign::Center)
+    }
+    fn align_h(self, h: HAlign) -> Node {
+        self.align(h, VAlign::Top)
+    }
+    fn align_v(self, v: VAlign) -> Node {
+        self.align(HAlign::Left, v)
+    }
+
+    // ── Image fit (CSS `object-fit`) ──────────────────────────────────
+    fn fit(self, mode: Fit) -> Node {
+        Node::Fit {
+            mode,
+            child: Box::new(self.into_node()),
+        }
+    }
+    fn fit_contain(self) -> Node {
+        self.fit(Fit::Contain)
+    }
+    fn fit_cover(self) -> Node {
+        self.fit(Fit::Cover)
+    }
+    fn fit_stretch(self) -> Node {
+        self.fit(Fit::Stretch)
+    }
+
+    // ── Painting ──────────────────────────────────────────────────────
+    fn background(self, c: Color) -> Node {
+        Node::Background {
+            color: c,
+            child: Box::new(self.into_node()),
+        }
+    }
+    fn border(self, c: Color) -> Node {
+        Node::Border {
+            color: c,
+            child: Box::new(self.into_node()),
+        }
+    }
+
+    // ── Label shortcuts ───────────────────────────────────────────────
+    fn label(self, s: impl Into<String>) -> Node {
+        self.label_styled(s, &LabelStyle::default())
+    }
+    fn label_styled(self, s: impl Into<String>, style: &LabelStyle) -> Node {
+        super::stack::column()
+            .gap(0)
+            .child(style.strip(s))
+            .child(self.into_node())
+            .into()
+    }
+    fn label_segments(self, segments: Vec<LabelSegment>, style: &LabelStyle) -> Node {
+        super::stack::column()
+            .gap(0)
+            .child(style.segmented_strip(segments))
+            .child(self.into_node())
+            .into()
+    }
+
+    /// Render this tree into an [`RgbaImage`] of width `max_w`.
+    /// Convenience for [`super::render`] when chaining off a builder.
+    fn render(self, max_w: u32) -> RgbaImage {
+        super::render(&self.into_node(), max_w)
+    }
+}
+
+impl LayoutMod for Node {
+    fn into_node(self) -> Node {
+        self
+    }
+}
+impl LayoutMod for super::stack::Stack {
+    fn into_node(self) -> Node {
+        self.into()
+    }
+}
+impl LayoutMod for super::grid::Grid {
+    fn into_node(self) -> Node {
+        self.into()
+    }
+}
+impl LayoutMod for super::layers::Layers {
+    fn into_node(self) -> Node {
+        self.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::color::{BLACK, WHITE};
+    use super::super::node::{empty, image as image_node};
+    use super::*;
+    use image::{Rgba, RgbaImage};
+
+    fn solid(w: u32, h: u32, c: Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    #[test]
+    fn padded_grows_by_insets() {
+        let n = image_node(solid(50, 30, WHITE)).padding(10);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(70, 50));
+    }
+    #[test]
+    fn size_overrides() {
+        let n = image_node(solid(50, 30, WHITE)).size(100, 80);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(100, 80));
+    }
+    #[test]
+    fn fill_width_consumes_max() {
+        let n = image_node(solid(50, 30, WHITE)).fill_width();
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(200, 30));
+    }
+    #[test]
+    fn min_width_grows_to_minimum() {
+        let n = image_node(solid(10, 10, WHITE)).min_width(50);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(50, 10));
+    }
+    #[test]
+    fn max_width_caps_natural() {
+        let n = image_node(solid(80, 10, WHITE)).max_width(40);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(40, 10));
+    }
+    #[test]
+    fn aspect_ratio_16_9_from_width() {
+        let n = image_node(solid(160, 50, WHITE)).aspect_ratio(16, 9);
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(160, 90));
+    }
+    #[test]
+    fn align_centers_in_oversized_rect() {
+        let img = image_node(solid(20, 10, [255, 255, 0, 255]))
+            .center()
+            .size(100, 60)
+            .render(100);
+        assert_eq!(img.get_pixel(50, 30), &Rgba([255, 255, 0, 255]));
+        assert_eq!(img.get_pixel(0, 0), &Rgba(BLACK));
+    }
+    #[test]
+    fn background_paints_first() {
+        let img = empty()
+            .background([10, 20, 30, 255])
+            .size(20, 20)
+            .render(20);
+        assert_eq!(img.get_pixel(5, 5), &Rgba([10, 20, 30, 255]));
+    }
+    #[test]
+    fn border_paints_outline() {
+        let img = empty()
+            .background(BLACK)
+            .border(WHITE)
+            .size(10, 10)
+            .render(10);
+        assert_eq!(img.get_pixel(0, 0), &Rgba(WHITE));
+        assert_eq!(img.get_pixel(9, 0), &Rgba(WHITE));
+        assert_eq!(img.get_pixel(5, 5), &Rgba(BLACK));
+    }
+    #[test]
+    fn fit_contain_letterboxes() {
+        let img = image_node(solid(20, 10, [255, 0, 0, 255]))
+            .fit_contain()
+            .size(40, 40)
+            .render(40);
+        assert_eq!(img.get_pixel(20, 0), &Rgba(BLACK));
+        assert_eq!(img.get_pixel(20, 20), &Rgba([255, 0, 0, 255]));
+    }
+}

--- a/zensim-regress/src/layout/node.rs
+++ b/zensim-regress/src/layout/node.rs
@@ -1,0 +1,413 @@
+//! The retained-tree IR — one [`Node`] enum covering leaves, containers,
+//! and modifiers, plus the top-level [`Node::measure`] / [`Node::paint`]
+//! dispatch tables.
+//!
+//! The dispatch arms delegate to per-variant helpers in:
+//! - [`super::paint`] — image/text leaves and primitives,
+//! - [`super::stack`] / [`super::grid`] / [`super::layers`] — containers,
+//! - [`super::modifiers`] — modifier nodes.
+
+use image::RgbaImage;
+
+use super::color::Color;
+use super::geom::Size;
+use super::safety;
+use super::sizing::{Fit, SizeRule};
+use super::text::TextSpec;
+use super::{geom, grid, layers, modifiers, paint, stack};
+
+/// The retained layout tree.
+///
+/// Construct via the free functions ([`image`], [`text`], [`line`],
+/// [`fill`], [`empty`]) and the builders in
+/// [`super::stack`] / [`super::grid`] / [`super::layers`]; chain
+/// modifiers from the [`super::LayoutMod`] trait.
+#[derive(Clone, Debug)]
+pub enum Node {
+    // ── Leaves ────────────────────────────────────────────────────────
+    Empty,
+    Fill(Color),
+    Image(RgbaImage),
+    Text(TextSpec),
+
+    // ── Containers ────────────────────────────────────────────────────
+    Stack {
+        axis: geom::Axis,
+        gap: u32,
+        justify: super::sizing::MainAlign,
+        align_items: super::sizing::CrossAlign,
+        children: Vec<Node>,
+    },
+    Grid {
+        cols: Vec<super::sizing::Track>,
+        rows: Vec<super::sizing::Track>,
+        gap: (u32, u32),
+        pad: u32,
+        cells: Vec<(grid::GridSpan, Node)>,
+    },
+    Layers(Vec<Node>),
+
+    // ── Modifiers ─────────────────────────────────────────────────────
+    Padded {
+        insets: geom::Insets,
+        child: Box<Node>,
+    },
+    Sized {
+        w: SizeRule,
+        h: SizeRule,
+        child: Box<Node>,
+    },
+    Constrain {
+        min_w: Option<u32>,
+        max_w: Option<u32>,
+        min_h: Option<u32>,
+        max_h: Option<u32>,
+        child: Box<Node>,
+    },
+    Aspect {
+        num: u32,
+        den: u32,
+        child: Box<Node>,
+    },
+    Align {
+        h: geom::HAlign,
+        v: geom::VAlign,
+        child: Box<Node>,
+    },
+    Fit {
+        mode: Fit,
+        child: Box<Node>,
+    },
+    Background {
+        color: Color,
+        child: Box<Node>,
+    },
+    Border {
+        color: Color,
+        child: Box<Node>,
+    },
+
+    // ── Specialised composite nodes ───────────────────────────────────
+    /// A label strip with multiple aligned segments. Width-aware: at
+    /// paint time, computes a single `char_h` that lets all segments
+    /// fit side-by-side within the actual rect, so it works at any
+    /// strip width without caller char_h tuning. See
+    /// [`super::label::LabelStyle::segmented_strip`].
+    SegmentedStrip {
+        segments: Vec<super::label::LabelSegment>,
+        style: Box<super::label::LabelStyle>,
+    },
+}
+
+// ── Implicit conversions ───────────────────────────────────────────────
+
+impl From<&str> for Node {
+    /// Default: white text on black (pre-blended). For non-default
+    /// background, use [`text`] / [`line`] explicitly.
+    fn from(s: &str) -> Node {
+        Node::Text(TextSpec::lines(
+            vec![(s.to_string(), super::color::WHITE)],
+            super::color::BLACK,
+        ))
+    }
+}
+
+impl From<String> for Node {
+    fn from(s: String) -> Node {
+        Node::Text(TextSpec::lines(
+            vec![(s, super::color::WHITE)],
+            super::color::BLACK,
+        ))
+    }
+}
+
+impl From<RgbaImage> for Node {
+    fn from(img: RgbaImage) -> Node {
+        Node::Image(img)
+    }
+}
+
+// ── Free-function leaf constructors ────────────────────────────────────
+
+pub fn empty() -> Node {
+    Node::Empty
+}
+pub fn fill(c: Color) -> Node {
+    Node::Fill(c)
+}
+pub fn image(img: RgbaImage) -> Node {
+    Node::Image(img)
+}
+pub fn text(spec: TextSpec) -> Node {
+    Node::Text(spec)
+}
+
+/// Default minimum padding (in pixels) wrapped around [`line`]'s text
+/// so it doesn't kiss the edges of a tight container. Use [`text`]
+/// directly for raw, no-padding text.
+pub const DEFAULT_LINE_PADDING: u32 = 4;
+
+/// Single-line text on a transparent background, sized to fit the
+/// constraint width, with [`DEFAULT_LINE_PADDING`] of breathing room
+/// applied uniformly. For text without padding, use [`text`] directly.
+pub fn line(s: impl Into<String>, fg: Color) -> Node {
+    use super::modifiers::LayoutMod;
+    Node::Text(TextSpec::lines(
+        vec![(s.into(), fg)],
+        super::color::TRANSPARENT,
+    ))
+    .padding(DEFAULT_LINE_PADDING)
+}
+
+// ── Dispatch tables ────────────────────────────────────────────────────
+
+impl Node {
+    /// Measure this node given the maximum available `(w, h)`. The
+    /// returned size is clamped to `max` and to [`safety::MAX_DIM`].
+    /// If recursion exceeds [`safety::MAX_DEPTH`] (e.g., a malicious
+    /// or deserialized tree with absurd nesting), [`Size::ZERO`] is
+    /// returned.
+    pub fn measure(&self, max: Size) -> Size {
+        safety::with_depth(|| {
+            let raw = self.measure_raw(max);
+            safety::clamp_size(Size::new(raw.w.min(max.w), raw.h.min(max.h)))
+        })
+        .unwrap_or(Size::ZERO)
+    }
+
+    fn measure_raw(&self, max: Size) -> Size {
+        match self {
+            Node::Empty | Node::Fill(_) => Size::ZERO,
+            Node::Image(img) => Size::new(img.width(), img.height()),
+            Node::Text(spec) => spec.natural(max.w, max.h),
+            Node::Stack {
+                axis,
+                gap,
+                children,
+                ..
+            } => stack::measure(*axis, *gap, children, max),
+            Node::Grid {
+                cols,
+                rows,
+                gap,
+                pad,
+                cells,
+            } => grid::measure(cols, rows, *gap, *pad, cells, max),
+            Node::Layers(children) => layers::measure(children, max),
+            Node::Padded { insets, child } => modifiers::measure_padded(*insets, child, max),
+            Node::Sized { w, h, child } => modifiers::measure_sized(*w, *h, child, max),
+            Node::Constrain {
+                min_w,
+                max_w,
+                min_h,
+                max_h,
+                child,
+            } => modifiers::measure_constrain(*min_w, *max_w, *min_h, *max_h, child, max),
+            Node::Aspect { num, den, child } => modifiers::measure_aspect(*num, *den, child, max),
+            Node::Align { child, .. }
+            | Node::Fit { child, .. }
+            | Node::Background { child, .. }
+            | Node::Border { child, .. } => child.measure(max),
+
+            Node::SegmentedStrip { segments, style } => {
+                super::label::measure_segmented_strip(segments, style, max)
+            }
+        }
+    }
+
+    /// Walk the tree and multiply every fixed-pixel quantity by
+    /// `scale` (Sized::Fixed, Insets, Track::Px, gap, pad, char_h).
+    /// Relative quantities (Hug / Fill / Grow / Percent / Fr / Auto)
+    /// are unchanged. `scale == 1.0`, `<= 0.0`, or non-finite returns
+    /// `self` unchanged (no allocation).
+    ///
+    /// Used by [`super::render_with_config`] to apply a CSS-`dppx`-style
+    /// uniform scale at render time.
+    pub fn scaled(self, scale: f32) -> Self {
+        if scale == 1.0 || scale <= 0.0 || !scale.is_finite() {
+            return self;
+        }
+        let s = |v: u32| ((v as f32) * scale).round() as u32;
+        match self {
+            Node::Empty | Node::Fill(_) | Node::Image(_) => self,
+            Node::Text(spec) => Node::Text(spec.scaled(scale)),
+            Node::Stack {
+                axis,
+                gap,
+                justify,
+                align_items,
+                children,
+            } => Node::Stack {
+                axis,
+                justify,
+                align_items,
+                gap: s(gap),
+                children: children.into_iter().map(|c| c.scaled(scale)).collect(),
+            },
+            Node::Grid {
+                cols,
+                rows,
+                gap,
+                pad,
+                cells,
+            } => Node::Grid {
+                cols: cols.into_iter().map(|t| t.scaled(scale)).collect(),
+                rows: rows.into_iter().map(|t| t.scaled(scale)).collect(),
+                gap: (s(gap.0), s(gap.1)),
+                pad: s(pad),
+                cells: cells
+                    .into_iter()
+                    .map(|(span, n)| (span, n.scaled(scale)))
+                    .collect(),
+            },
+            Node::Layers(children) => {
+                Node::Layers(children.into_iter().map(|c| c.scaled(scale)).collect())
+            }
+            Node::Padded { insets, child } => Node::Padded {
+                insets: insets.scaled(scale),
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Sized { w, h, child } => Node::Sized {
+                w: w.scaled(scale),
+                h: h.scaled(scale),
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Constrain {
+                min_w,
+                max_w,
+                min_h,
+                max_h,
+                child,
+            } => Node::Constrain {
+                min_w: min_w.map(s),
+                max_w: max_w.map(s),
+                min_h: min_h.map(s),
+                max_h: max_h.map(s),
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Aspect { num, den, child } => Node::Aspect {
+                num,
+                den,
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Align { h, v, child } => Node::Align {
+                h,
+                v,
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Fit { mode, child } => Node::Fit {
+                mode,
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Background { color, child } => Node::Background {
+                color,
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::Border { color, child } => Node::Border {
+                color,
+                child: Box::new(child.scaled(scale)),
+            },
+            Node::SegmentedStrip {
+                segments,
+                mut style,
+            } => {
+                // Scale only the explicit `char_h` cap and `padding`.
+                // The auto-fit char_h derived at paint time already
+                // adapts to the (scaled) rect width.
+                if let Some(h) = style.char_h {
+                    style.char_h = Some(((h as f32) * scale).round() as u32);
+                }
+                style.padding = style.padding.scaled(scale);
+                let segments = segments
+                    .into_iter()
+                    .map(|mut s| {
+                        if let Some(h) = s.char_h {
+                            s.char_h = Some(((h as f32) * scale).round() as u32);
+                        }
+                        s
+                    })
+                    .collect();
+                Node::SegmentedStrip { segments, style }
+            }
+        }
+    }
+
+    pub(super) fn paint(&self, rect: super::geom::Rect, canvas: &mut RgbaImage) {
+        if rect.w == 0 || rect.h == 0 {
+            return;
+        }
+        // Bounce out at recursion-depth cap — return without painting
+        // rather than overflowing the stack on hostile trees.
+        let Some(()) = safety::with_depth(|| self.paint_inner(rect, canvas)) else {
+            return;
+        };
+    }
+
+    fn paint_inner(&self, rect: super::geom::Rect, canvas: &mut RgbaImage) {
+        match self {
+            Node::Empty => {}
+            Node::Fill(c) => paint::fill_rect(canvas, rect, *c),
+            Node::Image(img) => paint::render_image(img, Fit::None, rect, canvas),
+            Node::Text(spec) => paint::render_text(spec, rect, canvas),
+            Node::Stack {
+                axis,
+                gap,
+                justify,
+                align_items,
+                children,
+            } => stack::paint(*axis, *gap, *justify, *align_items, children, rect, canvas),
+            Node::Grid {
+                cols,
+                rows,
+                gap,
+                pad,
+                cells,
+            } => grid::paint(cols, rows, *gap, *pad, cells, rect, canvas),
+            Node::Layers(children) => layers::paint(children, rect, canvas),
+            Node::Padded { insets, child } => modifiers::paint_padded(*insets, child, rect, canvas),
+            Node::Sized { child, .. }
+            | Node::Constrain { child, .. }
+            | Node::Aspect { child, .. } => child.paint(rect, canvas),
+            Node::Align { h, v, child } => modifiers::paint_align(*h, *v, child, rect, canvas),
+            Node::Fit { mode, child } => modifiers::paint_fit(*mode, child, rect, canvas),
+            Node::Background { color, child } => {
+                modifiers::paint_background(*color, child, rect, canvas)
+            }
+            Node::Border { color, child } => modifiers::paint_border(*color, child, rect, canvas),
+
+            Node::SegmentedStrip { segments, style } => {
+                super::label::paint_segmented_strip(segments, style, rect, canvas);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::color::WHITE;
+    use super::*;
+    use image::Rgba;
+
+    fn solid(w: u32, h: u32, c: Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    #[test]
+    fn empty_measures_zero() {
+        assert_eq!(empty().measure(Size::new(100, 100)), Size::ZERO);
+    }
+    #[test]
+    fn image_natural_size() {
+        let n: Node = solid(50, 30, [255, 0, 0, 255]).into();
+        assert_eq!(n.measure(Size::new(200, 200)), Size::new(50, 30));
+    }
+    #[test]
+    fn from_str_makes_text_node() {
+        let n: Node = "hello".into();
+        assert!(matches!(n, Node::Text(_)));
+    }
+    #[test]
+    fn line_helper_uses_provided_fg() {
+        let _ = line("hi", WHITE);
+    }
+}

--- a/zensim-regress/src/layout/paint.rs
+++ b/zensim-regress/src/layout/paint.rs
@@ -1,0 +1,150 @@
+//! Low-level pixel rendering — image and text leaves, plus the rect
+//! drawing primitives. Called by both the per-modifier paint paths
+//! ([`super::node::Node::paint`]) and the public render entry points.
+
+use image::{Rgba, RgbaImage, imageops};
+
+use super::color::Color;
+use super::geom::Rect;
+use super::sizing::Fit;
+use super::text::TextSpec;
+
+pub fn fill_rect(img: &mut RgbaImage, rect: Rect, color: Color) {
+    let px = Rgba(color);
+    let img_w = img.width();
+    let img_h = img.height();
+    let x_end = rect.x.saturating_add(rect.w).min(img_w);
+    let y_end = rect.y.saturating_add(rect.h).min(img_h);
+    for y in rect.y..y_end {
+        for x in rect.x..x_end {
+            img.put_pixel(x, y, px);
+        }
+    }
+}
+
+pub fn draw_rect_border(img: &mut RgbaImage, rect: Rect, color: Color) {
+    if rect.w == 0 || rect.h == 0 {
+        return;
+    }
+    let px = Rgba(color);
+    let img_w = img.width();
+    let img_h = img.height();
+    let x_end = rect.x.saturating_add(rect.w).min(img_w);
+    let y_end = rect.y.saturating_add(rect.h).min(img_h);
+    for x in rect.x..x_end {
+        if rect.y < img_h {
+            img.put_pixel(x, rect.y, px);
+        }
+        let bot = y_end.saturating_sub(1);
+        if bot < img_h && bot > rect.y {
+            img.put_pixel(x, bot, px);
+        }
+    }
+    for y in rect.y..y_end {
+        if rect.x < img_w {
+            img.put_pixel(rect.x, y, px);
+        }
+        let right = x_end.saturating_sub(1);
+        if right < img_w && right > rect.x {
+            img.put_pixel(right, y, px);
+        }
+    }
+}
+
+/// Paint an image leaf into `rect` with the given [`Fit`] mode.
+///
+/// `Fit::None` and `Fit::Stretch` (no resize needed) place the image at
+/// the rect's top-left; `Fit::Contain` and `Fit::Cover` center within
+/// the rect.
+pub(super) fn render_image(img: &RgbaImage, mode: Fit, rect: Rect, canvas: &mut RgbaImage) {
+    if rect.w == 0 || rect.h == 0 {
+        return;
+    }
+    let (iw, ih) = (img.width(), img.height());
+    if iw == 0 || ih == 0 {
+        return;
+    }
+    let scaled: Option<RgbaImage> = match mode {
+        Fit::None => None,
+        Fit::Stretch if (iw, ih) != (rect.w, rect.h) => Some(imageops::resize(
+            img,
+            rect.w,
+            rect.h,
+            imageops::FilterType::Lanczos3,
+        )),
+        Fit::Stretch => None,
+        Fit::Contain | Fit::Cover => {
+            let sx = rect.w as f32 / iw as f32;
+            let sy = rect.h as f32 / ih as f32;
+            let s = if matches!(mode, Fit::Contain) {
+                sx.min(sy)
+            } else {
+                sx.max(sy)
+            };
+            let nw = (iw as f32 * s).round().max(1.0) as u32;
+            let nh = (ih as f32 * s).round().max(1.0) as u32;
+            Some(imageops::resize(
+                img,
+                nw,
+                nh,
+                imageops::FilterType::Lanczos3,
+            ))
+        }
+    };
+
+    let (src, sw, sh) = match &scaled {
+        Some(s) => (s, s.width(), s.height()),
+        None => (img, iw, ih),
+    };
+
+    let centered = matches!(mode, Fit::Contain | Fit::Cover);
+    let (dst_x, dst_y) = if centered {
+        (
+            rect.x.saturating_add(rect.w.saturating_sub(sw) / 2) as i64,
+            rect.y.saturating_add(rect.h.saturating_sub(sh) / 2) as i64,
+        )
+    } else {
+        (rect.x as i64, rect.y as i64)
+    };
+
+    if sw <= rect.w && sh <= rect.h {
+        imageops::overlay(canvas, src, dst_x, dst_y);
+    } else {
+        let crop_x = if centered {
+            sw.saturating_sub(rect.w) / 2
+        } else {
+            0
+        };
+        let crop_y = if centered {
+            sh.saturating_sub(rect.h) / 2
+        } else {
+            0
+        };
+        let cw = rect.w.min(sw);
+        let ch = rect.h.min(sh);
+        let cropped = imageops::crop_imm(src, crop_x, crop_y, cw, ch).to_image();
+        let (dst_x, dst_y) = if centered {
+            (
+                rect.x.saturating_add(rect.w.saturating_sub(cw) / 2) as i64,
+                rect.y.saturating_add(rect.h.saturating_sub(ch) / 2) as i64,
+            )
+        } else {
+            (rect.x as i64, rect.y as i64)
+        };
+        imageops::overlay(canvas, &cropped, dst_x, dst_y);
+    }
+}
+
+/// Paint a text leaf at the rect's top-left. The rasterizer is given
+/// `(rect.w, rect.h)` so glyph height shrinks to fit either axis.
+/// Wrap in [`super::node::Node::Align`] to reposition.
+pub(super) fn render_text(spec: &TextSpec, rect: Rect, canvas: &mut RgbaImage) {
+    let (buf, w, h) = spec.rasterize(rect.w, rect.h);
+    if w == 0 || h == 0 {
+        return;
+    }
+    let Some(img) = RgbaImage::from_raw(w, h, buf) else {
+        return;
+    };
+    imageops::overlay(canvas, &img, rect.x as i64, rect.y as i64);
+}

--- a/zensim-regress/src/layout/safety.rs
+++ b/zensim-regress/src/layout/safety.rs
@@ -1,0 +1,298 @@
+//! Resource caps that protect the layout engine from malicious or
+//! pathological trees — important if a [`super::Node`] ever lands via
+//! deserialization (JSON, MessagePack, …).
+//!
+//! Limits live in a single [`LayoutLimits`] struct and are propagated
+//! per-render via a thread-local. Set via the public
+//! [`super::render_with_limits`] entry point; everything inside reads
+//! the active limits via [`limits`] / [`clamp_dim`] / etc.
+//!
+//! Trees within the active limits behave normally; trees outside are
+//! silently clamped — the renderer never panics on input data alone.
+
+use std::cell::Cell;
+
+use super::geom::Size;
+
+/// Knobs for hostile-input defense — pass to
+/// [`super::render_with_limits`] to override the defaults for a single
+/// render.
+///
+/// All fields are simple counts with hard upper bounds. Increasing
+/// them costs memory; lowering them clamps more aggressively.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct LayoutLimits {
+    /// Maximum width or height in pixels. Bounds *per-axis* allocation
+    /// (e.g., a 100K-wide text strip). Default 8192.
+    pub max_dim: u32,
+
+    /// Maximum total canvas pixel count. The output is scaled down
+    /// (preserving aspect) when the measured tree exceeds this. At
+    /// RGBA8 the default 20 MP works out to 80 MB.
+    pub max_pixels: u32,
+
+    /// A constraint above this is treated as "unbounded": [`super::Track::Fr`]
+    /// tracks fall back to [`super::Track::Auto`] semantics so they
+    /// don't try to fill an effectively infinite axis (e.g., the
+    /// `u32::MAX/2` we hand the root vertical constraint).
+    pub unbounded_threshold: u32,
+
+    /// Maximum recursion depth across measure / paint passes. Tracked
+    /// via a thread-local; deeper trees return zero size or paint
+    /// nothing. Defends against pathologically nested modifiers.
+    pub max_depth: u16,
+
+    /// Maximum siblings honored in a [`super::Stack`] / [`super::Layers`]
+    /// container. Children past this index are silently ignored.
+    pub max_children: usize,
+
+    /// Maximum grid cells honored.
+    pub max_cells: usize,
+
+    /// Maximum number of grid tracks (cols or rows).
+    pub max_tracks: usize,
+
+    /// Maximum character pixel-height for text rasterization. Bounds
+    /// the *scaled font-strip* allocation (the engine resizes the
+    /// embedded glyph strip to `char_w × CHAR_COUNT × char_h` before
+    /// stamping), independent of the output canvas.
+    pub max_char_h: u32,
+}
+
+impl LayoutLimits {
+    /// Sensible defaults for diff-montage-style work — 20 MP canvas
+    /// budget, 8K per axis, 1024-px max single-character height. Set as
+    /// `LayoutLimits::default()`.
+    pub const DEFAULT: Self = Self {
+        max_dim: 8192,
+        max_pixels: 20_000_000,
+        unbounded_threshold: 1 << 20,
+        max_depth: 64,
+        max_children: 4096,
+        max_cells: 4096,
+        max_tracks: 256,
+        max_char_h: 1024,
+    };
+
+    /// Loose limits — for trusted local rendering or debugging.
+    /// 8K-tall characters, 200 MP canvas, deeper recursion.
+    pub const PERMISSIVE: Self = Self {
+        max_dim: 32_768,
+        max_pixels: 200_000_000,
+        unbounded_threshold: 1 << 22,
+        max_depth: 256,
+        max_children: 65_536,
+        max_cells: 65_536,
+        max_tracks: 4096,
+        max_char_h: 4096,
+    };
+
+    /// Tight limits — for definitely-untrusted input on a small
+    /// machine. 4 MP canvas, 32-deep recursion, 256 children/cells.
+    pub const STRICT: Self = Self {
+        max_dim: 2048,
+        max_pixels: 4_000_000,
+        unbounded_threshold: 1 << 18,
+        max_depth: 32,
+        max_children: 256,
+        max_cells: 256,
+        max_tracks: 64,
+        max_char_h: 256,
+    };
+}
+
+impl Default for LayoutLimits {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+// ── Thread-local propagation ──────────────────────────────────────────
+
+/// Default value of `em(1.0)` when no [`super::RenderConfig::base_em`]
+/// is in scope. Matches CSS's typical 16-px baseline.
+pub const DEFAULT_BASE_EM: u32 = 16;
+
+thread_local! {
+    static LIMITS: Cell<LayoutLimits> = const { Cell::new(LayoutLimits::DEFAULT) };
+    static DEPTH: Cell<u16> = const { Cell::new(0) };
+    static BASE_EM: Cell<u32> = const { Cell::new(DEFAULT_BASE_EM) };
+}
+
+/// Snapshot the limits active on this thread.
+pub fn limits() -> LayoutLimits {
+    LIMITS.with(|l| l.get())
+}
+
+/// Run `f` with `lim` as the active limits, restoring the previous
+/// value (and resetting the depth counter) on return.
+pub fn with_limits<R>(lim: LayoutLimits, f: impl FnOnce() -> R) -> R {
+    let prev = LIMITS.with(|l| l.replace(lim));
+    DEPTH.with(|d| d.set(0));
+    let r = f();
+    LIMITS.with(|l| l.set(prev));
+    r
+}
+
+// ── Clamp / cap helpers (read the active limits) ──────────────────────
+
+/// Clamp a single dimension to `limits().max_dim`.
+pub fn clamp_dim(v: u32) -> u32 {
+    v.min(limits().max_dim)
+}
+
+/// Clamp both axes of a [`Size`] to `limits().max_dim`.
+pub fn clamp_size(s: Size) -> Size {
+    Size::new(clamp_dim(s.w), clamp_dim(s.h))
+}
+
+/// Scale `s` down preserving aspect so `w × h <= limits().max_pixels`.
+/// Returned unchanged if already in budget.
+pub fn clamp_to_pixel_budget(s: Size) -> Size {
+    let cap = limits().max_pixels as u64;
+    let total = s.w as u64 * s.h as u64;
+    if total == 0 || total <= cap {
+        return s;
+    }
+    let ratio = (cap as f64 / total as f64).sqrt();
+    Size::new(
+        ((s.w as f64 * ratio).floor() as u32).max(1),
+        ((s.h as f64 * ratio).floor() as u32).max(1),
+    )
+}
+
+/// `true` when the value is large enough to be treated as "unbounded".
+pub fn is_unbounded(v: u32) -> bool {
+    v >= limits().unbounded_threshold
+}
+
+pub fn cap_children(n: usize) -> usize {
+    n.min(limits().max_children)
+}
+pub fn cap_cells(n: usize) -> usize {
+    n.min(limits().max_cells)
+}
+pub fn cap_tracks(n: usize) -> usize {
+    n.min(limits().max_tracks)
+}
+/// Clamp a char-height to `limits().max_char_h`. Apply at any entry
+/// point that converts char-height into a pixel buffer.
+pub fn clamp_char_h(h: u32) -> u32 {
+    h.min(limits().max_char_h)
+}
+
+/// Run `f` with the depth counter incremented. Returns `Some(f())`
+/// when depth ≤ `limits().max_depth`, `None` when the cap is hit.
+pub fn with_depth<R>(f: impl FnOnce() -> R) -> Option<R> {
+    let max = limits().max_depth;
+    DEPTH.with(|d| {
+        let v = d.get();
+        if v >= max {
+            return None;
+        }
+        d.set(v + 1);
+        let r = f();
+        d.set(v);
+        Some(r)
+    })
+}
+
+/// Reset the depth counter — called by the public render entry points
+/// so a panicking previous render doesn't poison subsequent calls on
+/// the same thread.
+pub fn reset_depth() {
+    DEPTH.with(|d| d.set(0));
+}
+
+// ── em() — text-relative units ────────────────────────────────────────
+
+/// Active `em(1.0)` in pixels for this thread. Set via
+/// [`super::RenderConfig::with_base_em`]; defaults to
+/// [`DEFAULT_BASE_EM`].
+pub fn base_em() -> u32 {
+    BASE_EM.with(|e| e.get())
+}
+
+/// Run `f` with `base` as the active em-baseline, restoring the
+/// previous value on return.
+pub fn with_base_em<R>(base: u32, f: impl FnOnce() -> R) -> R {
+    let prev = BASE_EM.with(|e| e.replace(base));
+    let r = f();
+    BASE_EM.with(|e| e.set(prev));
+    r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limits_are_reasonable() {
+        let d = LayoutLimits::default();
+        assert_eq!(d.max_pixels, 20_000_000);
+        assert_eq!(d.max_dim, 8192);
+        assert_eq!(d.max_char_h, 1024);
+    }
+
+    #[test]
+    fn clamp_dim_respects_active_limits() {
+        with_limits(LayoutLimits::STRICT, || {
+            assert_eq!(clamp_dim(u32::MAX), 2048);
+        });
+        with_limits(LayoutLimits::DEFAULT, || {
+            assert_eq!(clamp_dim(u32::MAX), 8192);
+        });
+    }
+
+    #[test]
+    fn clamp_to_pixel_budget_scales_aspect() {
+        with_limits(LayoutLimits::DEFAULT, || {
+            // 10000 × 10000 = 100 MP, budget 20 MP → ~4472 × 4472.
+            let out = clamp_to_pixel_budget(Size::new(10000, 10000));
+            assert!(out.w as u64 * out.h as u64 <= 20_000_000);
+            assert!(out.w >= 4400 && out.w <= 4500);
+        });
+    }
+
+    #[test]
+    fn clamp_to_pixel_budget_preserves_small() {
+        with_limits(LayoutLimits::DEFAULT, || {
+            let s = Size::new(100, 50);
+            assert_eq!(clamp_to_pixel_budget(s), s);
+        });
+    }
+
+    #[test]
+    fn unbounded_detects_root_sentinel() {
+        with_limits(LayoutLimits::DEFAULT, || {
+            assert!(is_unbounded(u32::MAX / 2));
+            assert!(!is_unbounded(1024));
+        });
+    }
+
+    #[test]
+    fn depth_caps_recursion() {
+        with_limits(LayoutLimits::DEFAULT, || {
+            fn recurse(n: u32) -> Option<u32> {
+                super::with_depth(|| {
+                    if n == 0 {
+                        Some(0)
+                    } else {
+                        recurse(n - 1).map(|v| v + 1)
+                    }
+                })
+                .flatten()
+            }
+            assert!(recurse(100).is_none()); // > MAX_DEPTH (64)
+            assert_eq!(recurse(32), Some(32));
+        });
+    }
+
+    #[test]
+    fn permissive_allows_deeper() {
+        with_limits(LayoutLimits::PERMISSIVE, || {
+            assert!(limits().max_depth >= 200);
+            assert!(limits().max_pixels >= 100_000_000);
+        });
+    }
+}

--- a/zensim-regress/src/layout/sizing.rs
+++ b/zensim-regress/src/layout/sizing.rs
@@ -1,0 +1,120 @@
+//! Sizing rules and stack-distribution enums — the vocabulary for "how
+//! big" and "how to fill remaining space."
+
+/// Main-axis distribution within a stack. CSS `justify-content`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum MainAlign {
+    #[default]
+    Start,
+    Center,
+    End,
+    /// Equal gaps between children, none at edges.
+    SpaceBetween,
+    /// Half-gaps at edges, full gaps between.
+    SpaceAround,
+    /// Equal gaps everywhere (between, before, after).
+    SpaceEvenly,
+}
+
+/// Cross-axis alignment of children within a stack. CSS `align-items`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum CrossAlign {
+    #[default]
+    Start,
+    Center,
+    End,
+    /// Stretch each child to fill the cross axis.
+    Stretch,
+}
+
+/// How an image leaf scales into its allotted rect — CSS `object-fit`.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+pub enum Fit {
+    /// Place at original size, top-left aligned, clipped if larger
+    /// (CSS `none` with `object-position: 0 0`).
+    #[default]
+    None,
+    /// Scale preserving aspect, fit entirely (letterbox).
+    Contain,
+    /// Scale preserving aspect, fill rect (crop overflow).
+    Cover,
+    /// Stretch to rect ignoring aspect.
+    Stretch,
+}
+
+/// Per-axis sizing rule for a node — CSS `width: auto/100%/<n>px`.
+///
+/// [`SizeRule::Grow`] is CSS `flex-grow: n` — among Grow children of a
+/// stack, remaining main-axis space is split proportionally.
+///
+/// [`SizeRule::Percent`] takes a unit fraction in `[0.0, 1.0]` —
+/// e.g. `Percent(0.5)` is CSS `width: 50%`.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub enum SizeRule {
+    /// Hug content (CSS `auto`).
+    #[default]
+    Hug,
+    /// Fixed pixel size.
+    Fixed(u32),
+    /// Fill the parent constraint (CSS `100%`).
+    Fill,
+    /// Weighted fill — CSS `flex-grow: n`.
+    Grow(u32),
+    /// Fraction of parent constraint, `[0.0, 1.0]`.
+    Percent(f32),
+}
+
+impl SizeRule {
+    pub(super) fn grow_weight(self) -> u32 {
+        match self {
+            SizeRule::Fill => 1,
+            SizeRule::Grow(w) => w,
+            _ => 0,
+        }
+    }
+
+    /// Multiply the fixed-pixel quantity by `scale`. Hug / Fill / Grow
+    /// / Percent are unchanged (they're already relative).
+    pub(super) fn scaled(self, scale: f32) -> Self {
+        match self {
+            SizeRule::Fixed(v) => SizeRule::Fixed(((v as f32) * scale).round() as u32),
+            other => other,
+        }
+    }
+}
+
+/// Grid track sizing — CSS `grid-template-columns` / `-rows`.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Track {
+    /// Fixed pixel size.
+    Px(u32),
+    /// Fraction of remaining space (CSS `<n>fr`).
+    Fr(u32),
+    /// Hug the maximum content size in this track (CSS `auto`).
+    Auto,
+    /// Fraction of total available track-axis space, `[0.0, 1.0]`.
+    Percent(f32),
+    /// Fraction of remaining space, never shrinking below `min_px` —
+    /// analogous to CSS `minmax(<min_px>px, <weight>fr)`. Use when you
+    /// need a hard minimum gap regardless of overflow content (e.g.,
+    /// the Fr column between left/right groups in a segmented label
+    /// strip — guarantees the groups stay at least `min_px` apart).
+    FrMin { weight: u32, min_px: u32 },
+}
+
+impl Track {
+    /// Multiply the fixed-pixel quantity by `scale`. Fr / Auto /
+    /// Percent are unchanged (they're already relative); for `FrMin`
+    /// only `min_px` scales, the weight stays.
+    pub(super) fn scaled(self, scale: f32) -> Self {
+        match self {
+            Track::Px(v) => Track::Px(((v as f32) * scale).round() as u32),
+            Track::FrMin { weight, min_px } => Track::FrMin {
+                weight,
+                min_px: ((min_px as f32) * scale).round() as u32,
+            },
+            other => other,
+        }
+    }
+}

--- a/zensim-regress/src/layout/stack.rs
+++ b/zensim-regress/src/layout/stack.rs
@@ -1,0 +1,367 @@
+//! Linear stack container — CSS `display: flex` with `flex-direction:
+//! row | column`. Distribution along the main axis is controlled by
+//! [`MainAlign`]; cross-axis alignment by [`CrossAlign`].
+
+use image::RgbaImage;
+
+use super::geom::{Axis, Rect, Size};
+use super::node::Node;
+use super::safety;
+use super::sizing::{CrossAlign, MainAlign};
+
+#[derive(Clone, Debug)]
+pub struct Stack {
+    axis: Axis,
+    gap: u32,
+    justify: MainAlign,
+    align_items: CrossAlign,
+    children: Vec<Node>,
+}
+
+impl Stack {
+    pub fn new(axis: Axis) -> Self {
+        Self {
+            axis,
+            gap: 0,
+            justify: MainAlign::Start,
+            align_items: CrossAlign::Start,
+            children: Vec::new(),
+        }
+    }
+
+    pub fn gap(mut self, g: u32) -> Self {
+        self.gap = g;
+        self
+    }
+    pub fn justify(mut self, j: MainAlign) -> Self {
+        self.justify = j;
+        self
+    }
+    pub fn align_items(mut self, a: CrossAlign) -> Self {
+        self.align_items = a;
+        self
+    }
+    pub fn child(mut self, c: impl Into<Node>) -> Self {
+        self.children.push(c.into());
+        self
+    }
+    pub fn children<I, N>(mut self, items: I) -> Self
+    where
+        I: IntoIterator<Item = N>,
+        N: Into<Node>,
+    {
+        self.children.extend(items.into_iter().map(Into::into));
+        self
+    }
+}
+
+impl From<Stack> for Node {
+    fn from(s: Stack) -> Node {
+        Node::Stack {
+            axis: s.axis,
+            gap: s.gap,
+            justify: s.justify,
+            align_items: s.align_items,
+            children: s.children,
+        }
+    }
+}
+
+/// Free-fn entry point for a horizontal [`Stack`].
+pub fn row() -> Stack {
+    Stack::new(Axis::Horizontal)
+}
+
+/// Free-fn entry point for a vertical [`Stack`].
+pub fn column() -> Stack {
+    Stack::new(Axis::Vertical)
+}
+
+// ── Measure / paint ────────────────────────────────────────────────────
+
+pub(super) fn measure(axis: Axis, gap: u32, children: &[Node], max: Size) -> Size {
+    if children.is_empty() {
+        return Size::ZERO;
+    }
+    let cap = safety::cap_children(children.len());
+    let children = &children[..cap];
+    let n = children.len() as u32;
+    let total_gap = gap.saturating_mul(n.saturating_sub(1));
+
+    let (main_max, cross_max) = match axis {
+        Axis::Horizontal => (max.w.saturating_sub(total_gap), max.h),
+        Axis::Vertical => (max.h.saturating_sub(total_gap), max.w),
+    };
+    let child_max = match axis {
+        Axis::Horizontal => Size::new(main_max, cross_max),
+        Axis::Vertical => Size::new(cross_max, main_max),
+    };
+
+    let mut main = 0u32;
+    let mut cross = 0u32;
+    for c in children {
+        let s = c.measure(child_max);
+        let (m, x) = match axis {
+            Axis::Horizontal => (s.w, s.h),
+            Axis::Vertical => (s.h, s.w),
+        };
+        main = main.saturating_add(m);
+        cross = cross.max(x);
+    }
+    main = main.saturating_add(total_gap);
+    match axis {
+        Axis::Horizontal => Size::new(main, cross),
+        Axis::Vertical => Size::new(cross, main),
+    }
+}
+
+#[allow(clippy::too_many_arguments, clippy::manual_checked_ops)]
+pub(super) fn paint(
+    axis: Axis,
+    gap: u32,
+    justify: MainAlign,
+    align_items: CrossAlign,
+    children: &[Node],
+    rect: Rect,
+    canvas: &mut RgbaImage,
+) {
+    if children.is_empty() {
+        return;
+    }
+    let cap = safety::cap_children(children.len());
+    let children = &children[..cap];
+    let n = children.len() as u32;
+    let total_gap = gap.saturating_mul(n.saturating_sub(1));
+    let (main_avail, cross_avail) = match axis {
+        Axis::Horizontal => (rect.w.saturating_sub(total_gap), rect.h),
+        Axis::Vertical => (rect.h.saturating_sub(total_gap), rect.w),
+    };
+    let child_max = match axis {
+        Axis::Horizontal => Size::new(main_avail, cross_avail),
+        Axis::Vertical => Size::new(cross_avail, main_avail),
+    };
+
+    // Per-child weight (Fill + Grow) and natural size.
+    let mut weights: Vec<u32> = vec![0; children.len()];
+    let mut measured: Vec<Size> = Vec::with_capacity(children.len());
+    let mut used_main = 0u32;
+    let mut total_weight = 0u32;
+    for (i, c) in children.iter().enumerate() {
+        let s = c.measure(child_max);
+        let w = main_grow_weight(c, axis);
+        weights[i] = w;
+        total_weight = total_weight.saturating_add(w);
+        let main_dim = match axis {
+            Axis::Horizontal => s.w,
+            Axis::Vertical => s.h,
+        };
+        if w == 0 {
+            used_main = used_main.saturating_add(main_dim);
+        }
+        measured.push(s);
+    }
+
+    let remainder = main_avail.saturating_sub(used_main);
+
+    // Distribute main-axis sizes — Hug children take their natural,
+    // weighted children split the remainder.
+    let mut main_sizes: Vec<u32> = vec![0; children.len()];
+    let mut allotted = 0u32;
+    let mut last_flex_idx: Option<usize> = None;
+    for i in 0..children.len() {
+        if weights[i] > 0 {
+            let share = if total_weight > 0 {
+                remainder * weights[i] / total_weight
+            } else {
+                0
+            };
+            main_sizes[i] = share;
+            allotted = allotted.saturating_add(share);
+            last_flex_idx = Some(i);
+        } else {
+            main_sizes[i] = match axis {
+                Axis::Horizontal => measured[i].w,
+                Axis::Vertical => measured[i].h,
+            };
+        }
+    }
+    if let Some(i) = last_flex_idx {
+        // Hand the leftover floor-rounding pixels to the last flex child
+        // so we don't lose pixels to integer division.
+        main_sizes[i] = main_sizes[i].saturating_add(remainder.saturating_sub(allotted));
+    }
+
+    let total_children_main: u32 = main_sizes.iter().sum();
+    let leftover = main_avail.saturating_sub(total_children_main);
+
+    // Justify-content offsetting.
+    let (mut cursor, lead_pad, extra_gap) = match justify {
+        MainAlign::Start => (0u32, 0u32, 0u32),
+        MainAlign::Center => (leftover / 2, 0, 0),
+        MainAlign::End => (leftover, 0, 0),
+        MainAlign::SpaceBetween if n > 1 => (0, 0, leftover / (n - 1)),
+        MainAlign::SpaceBetween => (0, 0, 0),
+        MainAlign::SpaceAround => {
+            let unit = if n > 0 { leftover / n } else { 0 };
+            (unit / 2, 0, unit)
+        }
+        MainAlign::SpaceEvenly => {
+            let unit = leftover / (n + 1);
+            (unit, 0, unit)
+        }
+    };
+    cursor = cursor.saturating_add(lead_pad);
+    cursor = cursor.saturating_add(match axis {
+        Axis::Horizontal => rect.x,
+        Axis::Vertical => rect.y,
+    });
+
+    for (i, child) in children.iter().enumerate() {
+        let m_size = main_sizes[i];
+        let cross_natural = match axis {
+            Axis::Horizontal => measured[i].h,
+            Axis::Vertical => measured[i].w,
+        };
+        let cross_size = match align_items {
+            CrossAlign::Stretch => cross_avail,
+            _ => cross_natural.min(cross_avail),
+        };
+        let cross_off = match align_items {
+            CrossAlign::Start | CrossAlign::Stretch => 0,
+            CrossAlign::Center => cross_avail.saturating_sub(cross_size) / 2,
+            CrossAlign::End => cross_avail.saturating_sub(cross_size),
+        };
+
+        let child_rect = match axis {
+            Axis::Horizontal => Rect::new(cursor, rect.y + cross_off, m_size, cross_size),
+            Axis::Vertical => Rect::new(rect.x + cross_off, cursor, cross_size, m_size),
+        };
+        child.paint(child_rect, canvas);
+
+        cursor = cursor.saturating_add(m_size);
+        if i + 1 < children.len() {
+            cursor = cursor.saturating_add(gap).saturating_add(extra_gap);
+        }
+    }
+}
+
+fn main_grow_weight(node: &Node, axis: Axis) -> u32 {
+    match node {
+        Node::Sized { w, h, .. } => {
+            let r = match axis {
+                Axis::Horizontal => *w,
+                Axis::Vertical => *h,
+            };
+            r.grow_weight()
+        }
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::color::{BLACK, WHITE};
+    use super::super::modifiers::LayoutMod;
+    use super::super::node::{empty, image as image_node};
+    use super::super::sizing::SizeRule;
+    use super::*;
+    use image::{Rgba, RgbaImage};
+
+    fn solid(w: u32, h: u32, c: super::super::color::Color) -> RgbaImage {
+        RgbaImage::from_pixel(w, h, Rgba(c))
+    }
+
+    #[test]
+    fn column_sums_main_max_cross() {
+        let n = column()
+            .gap(2)
+            .child(image_node(solid(10, 10, WHITE)))
+            .child(image_node(solid(20, 5, WHITE)));
+        assert_eq!(
+            Node::from(n).measure(Size::new(100, 100)),
+            Size::new(20, 17)
+        );
+    }
+    #[test]
+    fn row_sums_main_max_cross() {
+        let n = row()
+            .gap(4)
+            .child(image_node(solid(10, 10, WHITE)))
+            .child(image_node(solid(20, 5, WHITE)));
+        assert_eq!(
+            Node::from(n).measure(Size::new(100, 100)),
+            Size::new(34, 10)
+        );
+    }
+
+    #[test]
+    fn align_items_center_centers_in_cross() {
+        let small = image_node(solid(10, 10, [255, 0, 0, 255]));
+        let big = image_node(solid(40, 40, [0, 0, 0, 255]));
+        let n = column()
+            .align_items(CrossAlign::Center)
+            .child(small)
+            .child(big)
+            .render(40);
+        assert_eq!(n.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(n.get_pixel(0, 5), &Rgba([0, 0, 0, 255]));
+    }
+
+    #[test]
+    fn align_items_stretch_fills_cross() {
+        let strip = empty()
+            .background([255, 0, 0, 255])
+            .height(SizeRule::Fixed(5));
+        let big = image_node(solid(40, 40, BLACK));
+        let img = column()
+            .align_items(CrossAlign::Stretch)
+            .child(strip)
+            .child(big)
+            .size(40, 45)
+            .render(40);
+        assert_eq!(img.get_pixel(0, 0), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(39, 0), &Rgba([255, 0, 0, 255]));
+    }
+
+    #[test]
+    fn justify_space_between() {
+        let a = image_node(solid(10, 10, [255, 0, 0, 255]));
+        let b = image_node(solid(10, 10, [0, 0, 255, 255]));
+        let img = row()
+            .justify(MainAlign::SpaceBetween)
+            .child(a)
+            .child(b)
+            .size(50, 10)
+            .render(50);
+        assert_eq!(img.get_pixel(5, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(45, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grow_weights_distribute_remainder() {
+        let hug = image_node(solid(10, 10, [255, 0, 0, 255]));
+        let grow = empty().background([0, 0, 255, 255]).grow(2).fill_height();
+        let img = row()
+            .align_items(CrossAlign::Stretch)
+            .child(hug)
+            .child(grow)
+            .size(60, 10)
+            .render(60);
+        assert_eq!(img.get_pixel(5, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+
+    #[test]
+    fn grow_weights_split_2_to_1() {
+        let a = empty().background([255, 0, 0, 255]).grow(2);
+        let b = empty().background([0, 0, 255, 255]).grow(1);
+        let img = row()
+            .align_items(CrossAlign::Stretch)
+            .child(a)
+            .child(b)
+            .size(60, 10)
+            .render(60);
+        assert_eq!(img.get_pixel(20, 5), &Rgba([255, 0, 0, 255]));
+        assert_eq!(img.get_pixel(50, 5), &Rgba([0, 0, 255, 255]));
+    }
+}

--- a/zensim-regress/src/layout/text.rs
+++ b/zensim-regress/src/layout/text.rs
@@ -1,0 +1,215 @@
+//! Text leaf — wraps the [`crate::font`] entry points with a measure /
+//! rasterize split so the layout module's measure pass can compute
+//! sizes without rasterizing.
+//!
+//! `bg` is pre-blended into glyph alpha by the font rasterizer, so set
+//! it to match the background behind the text for clean edges.
+
+use super::color::Color;
+use super::geom::Size;
+use super::safety;
+use crate::font;
+
+#[derive(Clone, Debug)]
+pub enum TextStyle {
+    /// One or more lines, each with its own color, sized so the longest
+    /// fits within the constraint width. [`font::render_lines_fitted`].
+    Lines(Vec<(String, Color)>),
+    /// Single line at a fixed character pixel-height. [`font::render_text_height`].
+    Fixed {
+        text: String,
+        fg: Color,
+        char_h: u32,
+    },
+    /// Word-wrapped text at a fixed character pixel-height.
+    /// [`font::render_text_wrapped`].
+    Wrapped {
+        text: String,
+        fg: Color,
+        char_h: u32,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct TextSpec {
+    pub style: TextStyle,
+    /// Background color the glyph rasterizer alpha-blends against — set
+    /// to match the strip behind the text for clean edges.
+    pub bg: Color,
+}
+
+impl TextSpec {
+    pub fn lines(lines: Vec<(impl Into<String>, Color)>, bg: Color) -> Self {
+        Self {
+            style: TextStyle::Lines(lines.into_iter().map(|(s, c)| (s.into(), c)).collect()),
+            bg,
+        }
+    }
+    pub fn fixed(text: impl Into<String>, fg: Color, bg: Color, char_h: u32) -> Self {
+        Self {
+            style: TextStyle::Fixed {
+                text: text.into(),
+                fg,
+                char_h,
+            },
+            bg,
+        }
+    }
+    pub fn wrapped(text: impl Into<String>, fg: Color, bg: Color, char_h: u32) -> Self {
+        Self {
+            style: TextStyle::Wrapped {
+                text: text.into(),
+                fg,
+                char_h,
+            },
+            bg,
+        }
+    }
+
+    /// Multiply explicit `char_h` (in `Fixed` / `Wrapped` variants) by
+    /// `scale`. `Lines` is auto-fit and unchanged.
+    pub(super) fn scaled(self, scale: f32) -> Self {
+        let scale_h = |h: u32| ((h as f32) * scale).round() as u32;
+        Self {
+            bg: self.bg,
+            style: match self.style {
+                TextStyle::Lines(lines) => TextStyle::Lines(lines),
+                TextStyle::Fixed { text, fg, char_h } => TextStyle::Fixed {
+                    text,
+                    fg,
+                    char_h: scale_h(char_h),
+                },
+                TextStyle::Wrapped { text, fg, char_h } => TextStyle::Wrapped {
+                    text,
+                    fg,
+                    char_h: scale_h(char_h),
+                },
+            },
+        }
+    }
+
+    /// Rasterize against `(max_w, max_h)` — produces the pixel buffer
+    /// used at paint. Char height shrinks to fit *either* axis (so a
+    /// short string in a tall-narrow rect doesn't overflow downward).
+    /// `max_h == 0` means unbounded height; `max_w == 0` returns empty.
+    pub(super) fn rasterize(&self, max_w: u32, max_h: u32) -> (Vec<u8>, u32, u32) {
+        let max_w = safety::clamp_dim(max_w);
+        let max_h = safety::clamp_dim(max_h);
+        if max_w == 0 {
+            return (vec![], 0, 0);
+        }
+        let result = match &self.style {
+            TextStyle::Lines(lines) => {
+                let refs: Vec<(&str, Color)> =
+                    lines.iter().map(|(s, c)| (s.as_str(), *c)).collect();
+                let effective_max_w = lines_height_bounded_max_w(&refs, max_w, max_h);
+                font::render_lines_fitted(&refs, self.bg, effective_max_w)
+            }
+            TextStyle::Fixed { text, fg, char_h } => {
+                let ch = char_h_within_height(*char_h, max_h, 1);
+                font::render_text_height(text, *fg, self.bg, ch)
+            }
+            TextStyle::Wrapped { text, fg, char_h } => {
+                let ch = char_h_within_height(*char_h, max_h, 1);
+                font::render_text_wrapped(text, *fg, self.bg, ch, max_w)
+            }
+        };
+        let max_dim = safety::limits().max_dim;
+        if result.1 > max_dim || result.2 > max_dim {
+            return (vec![], 0, 0);
+        }
+        result
+    }
+
+    /// Cheap measure — no rasterization. Returns the natural `(w, h)`
+    /// the rasterized buffer would have given `(max_w, max_h)`.
+    pub(super) fn natural(&self, max_w: u32, max_h: u32) -> Size {
+        let max_w = safety::clamp_dim(max_w);
+        let max_h = safety::clamp_dim(max_h);
+        if max_w == 0 {
+            return Size::ZERO;
+        }
+        let (w, h) = match &self.style {
+            TextStyle::Lines(lines) => {
+                let refs: Vec<(&str, Color)> =
+                    lines.iter().map(|(s, c)| (s.as_str(), *c)).collect();
+                let effective_max_w = lines_height_bounded_max_w(&refs, max_w, max_h);
+                font::measure_lines_fitted(&refs, effective_max_w)
+            }
+            TextStyle::Fixed { text, char_h, .. } => {
+                let ch = char_h_within_height(*char_h, max_h, 1);
+                font::measure_text_height(text, ch)
+            }
+            TextStyle::Wrapped { text, char_h, .. } => {
+                let ch = char_h_within_height(*char_h, max_h, 1);
+                font::measure_text_wrapped(text, ch, max_w)
+            }
+        };
+        safety::clamp_size(Size::new(w, h))
+    }
+}
+
+/// Given a `Lines` text and a `(max_w, max_h)` rect, return the
+/// *effective* `max_w` to feed [`font::measure_lines_fitted`] /
+/// [`font::render_lines_fitted`] so that the resulting char height
+/// also fits within `max_h`.
+///
+/// `font::*_lines_fitted` derives char height from `max_w / longest *
+/// (BASE_H / BASE_W)`, then clamps to `[BASE_H/4, BASE_H]`. Inverting
+/// the formula gives a smaller `max_w` that yields the desired char
+/// height when height is the binding constraint.
+fn lines_height_bounded_max_w(refs: &[(&str, Color)], max_w: u32, max_h: u32) -> u32 {
+    if max_h == 0 || refs.is_empty() {
+        return max_w;
+    }
+    // Width-fit char height (after the lower clamp).
+    let longest = refs.iter().map(|(s, _)| s.len()).max().unwrap_or(1).max(1) as u32;
+    let n_lines = refs.len().max(1) as u32;
+    let h_at_full_w = (max_w as u64 * 54 / (longest as u64 * 26)) as u32;
+    let total_h_at_full_w = h_at_full_w * n_lines;
+    if total_h_at_full_w <= max_h {
+        return max_w;
+    }
+    let target_char_h = max_h / n_lines;
+    if target_char_h == 0 {
+        return 0;
+    }
+    let derived_max_w = ((target_char_h as u64) * (longest as u64) * 26 / 54) as u32;
+    derived_max_w.min(max_w).max(1)
+}
+
+/// Cap a fixed `char_h` to fit within `max_h` for `n_lines` lines,
+/// preserving the safety upper bound.
+fn char_h_within_height(char_h: u32, max_h: u32, n_lines: u32) -> u32 {
+    let base = safety::clamp_char_h(char_h);
+    if max_h == 0 || n_lines == 0 {
+        return base;
+    }
+    base.min(max_h / n_lines.max(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::color::{BLACK, WHITE};
+    use super::*;
+
+    #[test]
+    fn text_lines_measures_match_render() {
+        let spec = TextSpec::lines(
+            vec![("HELLO".to_string(), WHITE), ("WORLD!".to_string(), WHITE)],
+            BLACK,
+        );
+        let measured = spec.natural(200, 0);
+        let (_, w, h) = spec.rasterize(200, 0);
+        assert_eq!(measured, Size::new(w, h));
+    }
+
+    #[test]
+    fn text_lines_shrinks_to_fit_height() {
+        // 60×30 box, 1 char "a": width-fit alone → char_h=54 (overflow).
+        // Height-aware should produce char_h ≤ 30.
+        let spec = TextSpec::lines(vec![("a".to_string(), WHITE)], BLACK);
+        let s = spec.natural(60, 30);
+        assert!(s.h <= 30, "expected text to fit in 30-tall box, got {s:?}");
+    }
+}

--- a/zensim-regress/src/lib.rs
+++ b/zensim-regress/src/lib.rs
@@ -45,6 +45,8 @@ pub mod error;
 pub mod fetch;
 /// Minimal bitmap font for annotating diff images.
 pub mod font;
+/// Retained-tree layout primitives for composing labeled image grids.
+pub mod layout;
 /// Deterministic synthetic test image generators.
 pub mod generators;
 /// Pixel and file hashing (`ChecksumHasher` trait, `SeaHasher`).

--- a/zensim-regress/src/lib.rs
+++ b/zensim-regress/src/lib.rs
@@ -45,12 +45,27 @@ pub mod error;
 pub mod fetch;
 /// Minimal bitmap font for annotating diff images.
 pub mod font;
-/// Retained-tree layout primitives for composing labeled image grids.
-pub mod layout;
 /// Deterministic synthetic test image generators.
 pub mod generators;
 /// Pixel and file hashing (`ChecksumHasher` trait, `SeaHasher`).
 pub mod hasher;
+/// Retained-tree layout primitives for composing labeled image grids.
+///
+/// **Internal — not part of the stable public API.** Used by
+/// [`diff_image`]'s montage compositor and by debug examples. The
+/// surface (Node variants, modifier methods, render entry points) is
+/// expected to change as the image-crate → zen-ecosystem migration
+/// progresses; in particular `Node::Image` will likely change pixel
+/// type. Pinned external use will break.
+///
+/// Exposed publicly only when the `_internal_api` cargo feature is
+/// enabled (used by `examples/layout_gallery.rs`). For everything
+/// else use the [`diff_image::MontageOptions`] API.
+#[cfg(feature = "_internal_api")]
+#[doc(hidden)]
+pub mod layout;
+#[cfg(not(feature = "_internal_api"))]
+mod layout;
 /// Advisory file locking for parallel test safety.
 pub mod lock;
 /// TSV manifest writer for CI result aggregation across platforms.


### PR DESCRIPTION
## Summary

A retained-tree layout module for `zensim-regress`'s diff-montage compositor, plus a refactor of `diff_image.rs`'s three render functions onto it, plus safety caps for hostile-input defense, plus `RenderConfig` for `dppx`-style scaling and em-relative units. Layout is **internal-only** (gated on the `_internal_api` cargo feature).

## What's in this PR

1. **New `layout` module** (`src/layout/`, 12 files, ~2400 lines) — CSS-flavored fluent API. `Node` IR enum + `Stack`/`Grid`/`Layers` builders + `LayoutMod` modifier trait + `LabelStyle`/`LabelSegment` strip helpers.
2. **`diff_image.rs` ported.** `render_montage_impl` / `render_mismatched_montage` / `render_heatmap_grid` rewritten on the layout module. Two near-duplicate ~290-line composers collapsed into a shared `compose_montage` (~165 lines). `diff_image.rs` net **2232 → 1192 lines (-1040)**. Public API unchanged.
3. **Self-documenting gallery** (`examples/layout_gallery.rs`). Generates an HTML page where each scene shows source code beside its rendered PNG. 25 scenes covering leaves, stacks (justify / align_items / grow), grids (Px/Fr/Auto/Percent/areas/spans), layers, modifiers, label patterns, percent-sizing, scale-1.5×, em-relative, template-style data injection, and a mini-diff montage. **Gated on the `_internal_api` feature.**
4. **Safety caps** (`layout/safety.rs`). `LayoutLimits` struct with `max_dim` / `max_pixels` (20 MP default) / `max_depth` / `max_children` / `max_cells` / `max_tracks` / `max_char_h` / `unbounded_threshold`. Fr tracks fall back to Auto in unbounded constraints. `STRICT` / `DEFAULT` / `PERMISSIVE` presets. Thread-local plumbing via `with_limits`.
5. **`RenderConfig`** (separate from safety). `scale: f32` (CSS dppx — multiplies all fixed-pixel quantities via `Node::scaled`), `base_em: u32` (em baseline). `render_with_config` is the full-control entry point; `render` / `render_with` / `render_with_limits` delegate to it.
6. **`SizeRule::Percent(f32)` and `Track::Percent(f32)`** + `width_percent` / `height_percent` / `size_percent` modifier methods.
7. **`em(units: f32) -> u32`** free fn that reads thread-local base_em.
8. **Bugs caught and fixed during the regression-driven port:**
   - `render_grid` clipped the last column by `gap` pixels — added `grid_with_gap_last_col_full_width` regression test.
   - Image with `Fit::None` was centering when the rect was bigger than the image — switched to top-left placement (centering now via `.center()` or `Fit::Contain`/`Cover`).
   - Auto-fit text `char_h` shifted between measure and paint when an enclosing `Align` reduced the rect — pre-rasterize annotation strips into Image leaves to keep buffers stable.
   - Fr tracks in unbounded vertical constraints requested a `u32::MAX/2`-tall canvas (4-TB allocation) — Fr→Auto fallback when `is_unbounded`.

## Internal-only by default

`pub mod layout` is gated on the `_internal_api` cargo feature (underscore-prefixed to signal "do not depend on this externally"). Default builds: layout is `mod layout` (private). The `layout_gallery` example has `required-features = [\"_internal_api\"]`. This avoids version-coupling with downstream consumers as the layout API evolves alongside the [#18 image→zen migration](https://github.com/imazen/zensim/issues/18) — in particular `Node::Image` will likely change pixel type, which would otherwise be a breaking change.

The supported public API (`diff_image::MontageOptions`, `AnnotationText`, etc.) is unchanged.

## Stats

- **299 lib tests** pass (was ~235 pre-PR; +37 layout unit tests, +20 safety/limits/percent/scale/em tests, +5 layout-port tests).
- **Clippy clean** on default + `_internal_api` feature.
- **6/6 montage regression scenes byte-identical** to the pre-port baseline (verified via `examples/montage_diff` against captured baseline).
- Files: `+5341 -1188` net.

## Test plan

- [x] `cargo test -p zensim-regress --lib`
- [x] `cargo test -p zensim-regress --features _internal_api --lib`
- [x] `cargo clippy -p zensim-regress --lib --no-deps`
- [x] `cargo clippy -p zensim-regress --features _internal_api --lib --no-deps`
- [x] `cargo run -p zensim-regress --example montage_regression -- /tmp/baseline`
       (then port commit, regenerate, compare via `montage_diff` — pixel-identical)
- [x] `cargo run -p zensim-regress --features _internal_api --example layout_gallery`
       (open `/tmp/zenlayout_gallery/index.html` to scan API fluency)
- [ ] CI green on all platforms