### PR TITLE
fix: validate cross-image dims and harden allocation arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@
      Persist across patch releases. Only clear when the breaking release ships. -->
 _(none currently queued)_
 
+### Added (zensim, unreleased)
+- `Zensim::with_max_pixels(usize)` / `Zensim::max_pixels()` — opt-in cap on
+  `width × height` per image, enforced before allocation. Default `None`
+  (no cap). Use when feeding untrusted dimensions to avoid runaway allocation.
+- `try_score_from_features` — `Result`-returning replacement for the
+  panicking `score_from_features` (now deprecated, kept as a wrapper).
+- `PrecomputedReference::width()` / `height()` — public accessors so callers
+  can verify dimensions before passing distorted images to `compute_with_ref*`.
+- `ZensimError` variants `ImageTooLarge` and `FeatureWeightsLengthMismatch`.
+  `ZensimError` is now `#[non_exhaustive]`.
+
+### Fixed (zensim, unreleased)
+- `compute_with_ref*` (including `compute_with_ref_and_diffmap` and
+  `compute_with_ref_and_diffmap_linear_planar`) now rejects distorted
+  images whose dimensions differ from the precomputed reference with
+  `DimensionMismatch` instead of silently producing garbage scores or
+  panicking on slice out-of-range.
+- `RgbSlice` / `RgbaSlice` / `StridedBytes` now use `checked_mul` /
+  `checked_add` for `width × height` and stride arithmetic, returning
+  `ImageTooLarge` on overflow instead of wrapping silently on 32-bit /
+  wasm32 targets.
+- `simd_padded_width` saturates to `usize::MAX` instead of wrapping; every
+  downstream allocation site is now guarded by `checked_padded_plane_len`.
+
 ## zensim
 
 ### [0.2.8] - 2026-05-04

--- a/zensim-validate/src/main.rs
+++ b/zensim-validate/src/main.rs
@@ -1157,7 +1157,10 @@ fn main() {
             };
             let scores_and_dists: Vec<(f64, f64)> = feats
                 .iter()
-                .map(|f| zensim::score_from_features(f, w))
+                .map(|f| {
+                    zensim::try_score_from_features(f, w)
+                        .expect("features and weights length mismatch")
+                })
                 .collect();
             let custom_scores: Vec<f64> = scores_and_dists.iter().map(|&(s, _)| s).collect();
             let raw_dists: Vec<f64> = scores_and_dists.iter().map(|&(_, d)| d).collect();
@@ -1317,7 +1320,11 @@ fn main() {
                 let feats: Vec<&[f64]> = f.iter().map(|v| v.as_slice()).collect();
                 let trained_scores: Vec<f64> = feats
                     .iter()
-                    .map(|feat| zensim::score_from_features(feat, &best_weights).0)
+                    .map(|feat| {
+                        zensim::try_score_from_features(feat, &best_weights)
+                            .expect("features and weights length mismatch")
+                            .0
+                    })
                     .collect();
                 let srocc = spearman_correlation(h, &trained_scores);
                 log_line(
@@ -1732,7 +1739,11 @@ fn report_embedded_correlations(ds: &DatasetWithFeatures, log: &mut Vec<String>)
     let metric_scores: Vec<f64> = ds
         .features
         .iter()
-        .map(|f| zensim::score_from_features(f, &ew).0)
+        .map(|f| {
+            zensim::try_score_from_features(f, &ew)
+                .expect("features and weights length mismatch")
+                .0
+        })
         .collect();
 
     let srocc = spearman_correlation(&ds.human_scores, &metric_scores);
@@ -1767,7 +1778,11 @@ fn report_embedded_correlations(ds: &DatasetWithFeatures, log: &mut Vec<String>)
     let raw_dists: Vec<f64> = ds
         .features
         .iter()
-        .map(|f| zensim::score_from_features(f, &ew).1)
+        .map(|f| {
+            zensim::try_score_from_features(f, &ew)
+                .expect("features and weights length mismatch")
+                .1
+        })
         .collect();
     let min_d = raw_dists.iter().cloned().fold(f64::INFINITY, f64::min);
     let max_d = raw_dists.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
@@ -2023,7 +2038,8 @@ fn write_features_csv(path: &Path, human_scores: &[f64], features: &[Vec<f64>]) 
 
     let ew = expand_embedded_weights(n_features);
     for (human, feat) in human_scores.iter().zip(features) {
-        let (score, raw) = zensim::score_from_features(feat, &ew);
+        let (score, raw) = zensim::try_score_from_features(feat, &ew)
+            .expect("features and weights length mismatch");
         write!(f, "{},{},{}", human, score, raw).unwrap();
         for v in feat {
             write!(f, ",{}", v).unwrap();
@@ -3355,7 +3371,11 @@ fn print_trained_results(
 ) {
     let trained_scores: Vec<f64> = feats
         .iter()
-        .map(|f| zensim::score_from_features(f, weights).0)
+        .map(|f| {
+            zensim::try_score_from_features(f, weights)
+                .expect("features and weights length mismatch")
+                .0
+        })
         .collect();
 
     let srocc = spearman_correlation(human_scores, &trained_scores);
@@ -3751,7 +3771,11 @@ fn train_weights_multi(
 fn eval_srocc(human_scores: &[f64], features: &[&[f64]], weights: &[f64]) -> f64 {
     let predicted: Vec<f64> = features
         .iter()
-        .map(|f| zensim::score_from_features(f, weights).0)
+        .map(|f| {
+            zensim::try_score_from_features(f, weights)
+                .expect("features and weights length mismatch")
+                .0
+        })
         .collect();
     spearman_correlation(human_scores, &predicted)
 }

--- a/zensim-validate/src/scale_invariance.rs
+++ b/zensim-validate/src/scale_invariance.rs
@@ -348,7 +348,8 @@ fn compute_zensim_per_row(
                 };
                 // The result's score uses the embedded weights; for custom
                 // weights we re-score from the feature vector.
-                let (score, raw) = zensim::score_from_features(result.features(), weights);
+                let (score, raw) = zensim::try_score_from_features(result.features(), weights)
+                    .expect("features and weights length mismatch");
                 local.push((i, score, raw));
             }
             let n = progress.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/zensim/src/blur.rs
+++ b/zensim/src/blur.rs
@@ -2069,12 +2069,33 @@ fn downscale_2x_into_inner(
 /// rows is odd, spreading all 16 rows across distinct cache sets.
 /// Below 512, the working set fits in L1 and aliasing doesn't matter.
 pub(crate) fn simd_padded_width(width: usize) -> usize {
-    let aligned = (width + 15) & !15;
+    // For widths near `usize::MAX` the original `(width + 15) & !15` would
+    // wrap silently. Saturate to `usize::MAX` instead — every downstream
+    // allocation site that derives from `padded_width` is guarded by
+    // `padded_width.checked_mul(height)` (see [`checked_padded_plane_len`])
+    // and will surface `ImageTooLarge` rather than wrap.
+    let aligned = match width.checked_add(15) {
+        Some(v) => v & !15,
+        None => return usize::MAX,
+    };
     if aligned >= 512 && (aligned / 16).is_multiple_of(2) {
-        aligned + 16
+        aligned.saturating_add(16)
     } else {
         aligned
     }
+}
+
+/// Compute `padded_width * height` for plane-allocation sites with overflow
+/// detection. Used by streaming-pipeline paths whose dimensions originate
+/// from a public API that already validated `width × height` but not
+/// `padded_width × height`.
+pub(crate) fn checked_padded_plane_len(
+    padded_width: usize,
+    height: usize,
+) -> Result<usize, crate::ZensimError> {
+    padded_width
+        .checked_mul(height)
+        .ok_or(crate::ZensimError::ImageTooLarge)
 }
 
 #[cfg(test)]

--- a/zensim/src/diffmap.rs
+++ b/zensim/src/diffmap.rs
@@ -616,6 +616,12 @@ impl crate::metric::Zensim {
         if distorted.width() < 8 || distorted.height() < 8 {
             return Err(ZensimError::ImageTooSmall);
         }
+        crate::metric::validate_ref_match(precomputed, distorted)?;
+        crate::metric::check_within_max_pixels(
+            distorted.width(),
+            distorted.height(),
+            self.max_pixels(),
+        )?;
 
         let width = distorted.width();
         let height = distorted.height();

--- a/zensim/src/diffmap.rs
+++ b/zensim/src/diffmap.rs
@@ -696,6 +696,13 @@ impl crate::metric::Zensim {
     /// # Errors
     ///
     /// Returns [`ZensimError::ImageTooSmall`] if dimensions < 8×8.
+    /// Returns [`ZensimError::DimensionMismatch`] if `width` / `height`
+    /// differ from the precomputed reference's recorded dimensions.
+    /// Returns [`ZensimError::ImageTooLarge`] if `width × height` exceeds
+    /// the configured `max_pixels` cap or if `stride × height` overflows
+    /// `usize`. Returns [`ZensimError::InvalidStride`] if `stride < width`.
+    /// Returns [`ZensimError::InvalidDataLength`] if any plane is shorter
+    /// than `stride × height`.
     pub fn compute_with_ref_and_diffmap_linear_planar(
         &self,
         precomputed: &PrecomputedReference,
@@ -709,6 +716,23 @@ impl crate::metric::Zensim {
         let params = self.profile().params();
         if width < 8 || height < 8 {
             return Err(ZensimError::ImageTooSmall);
+        }
+        if precomputed.width() != width || precomputed.height() != height {
+            return Err(ZensimError::DimensionMismatch);
+        }
+        crate::metric::check_within_max_pixels(width, height, self.max_pixels())?;
+        if stride < width {
+            return Err(ZensimError::InvalidStride);
+        }
+        // `stride * height` must fit in usize; reject overflow up front so
+        // downstream `y * stride + x` arithmetic cannot wrap on 32-bit.
+        let row_capacity = stride
+            .checked_mul(height)
+            .ok_or(ZensimError::ImageTooLarge)?;
+        for plane in &planes {
+            if plane.len() < row_capacity {
+                return Err(ZensimError::InvalidDataLength);
+            }
         }
 
         let config = config_from_params(params, self.parallel());

--- a/zensim/src/error.rs
+++ b/zensim/src/error.rs
@@ -1,6 +1,11 @@
 //! Error types for zensim image comparison.
 
 /// Errors from zensim computation.
+///
+/// This enum is `#[non_exhaustive]` — additional variants may be added in
+/// future minor releases without a major version bump. Match with a `_`
+/// arm to remain forward-compatible.
+#[non_exhaustive]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ZensimError {
     /// Source and distorted images have different pixel counts.
@@ -19,6 +24,14 @@ pub enum ZensimError {
     /// Row stride is smaller than `width * bytes_per_pixel`.
     #[error("Row stride is smaller than width * bytes_per_pixel")]
     InvalidStride,
+
+    /// Image dimensions exceed the configured `max_pixels` cap, or the
+    /// notional pixel/byte count overflows `usize` on the current target
+    /// (e.g. `width * height` wraps on 32-bit / wasm32). Use
+    /// [`Zensim::with_max_pixels`](crate::Zensim::with_max_pixels) to
+    /// raise or remove the cap.
+    #[error("Image dimensions exceed the configured maximum or overflow usize")]
+    ImageTooLarge,
 }
 
 /// Pixel format conversion error from the zenpixels adapter.

--- a/zensim/src/error.rs
+++ b/zensim/src/error.rs
@@ -32,6 +32,12 @@ pub enum ZensimError {
     /// raise or remove the cap.
     #[error("Image dimensions exceed the configured maximum or overflow usize")]
     ImageTooLarge,
+
+    /// `features.len()` does not equal `weights.len()` in
+    /// [`try_score_from_features`](crate::try_score_from_features). Both
+    /// slices must have the same length (one weight per feature).
+    #[error("features and weights must have the same length")]
+    FeatureWeightsLengthMismatch,
 }
 
 /// Pixel format conversion error from the zenpixels adapter.

--- a/zensim/src/lib.rs
+++ b/zensim/src/lib.rs
@@ -238,11 +238,14 @@ pub use streaming::{PrecomputedReference, ZensimScratch};
 /// with non-default `ZensimConfig` are **not comparable** to the default
 /// trained weights or the 0-100 score scale.
 #[cfg(feature = "training")]
+#[allow(deprecated)]
+pub use metric::score_from_features;
+#[cfg(feature = "training")]
 pub use metric::{
     BlurKernel, CH_B, CH_X, CH_Y, DownscaleFilter, FEATURES_PER_CHANNEL_BASIC,
     FEATURES_PER_CHANNEL_EXTENDED, FEATURES_PER_CHANNEL_WITH_PEAKS, FEATURES_PER_SCALE, WEIGHTS,
     ZensimConfig, compute_zensim_with_config, compute_zensim_with_ref_and_config,
-    precompute_reference_with_scales, score_from_features,
+    precompute_reference_with_scales, try_score_from_features,
 };
 
 #[cfg(feature = "zenpixels")]

--- a/zensim/src/metric.rs
+++ b/zensim/src/metric.rs
@@ -305,16 +305,40 @@ fn distance_to_score_mapped(raw_distance: f64, a: f64, b: f64) -> f64 {
 }
 
 /// Compute score from raw features using custom weights.
-/// `features`: raw features from ZensimResult.features
-/// `weights`: one weight per feature (len must equal features.len())
-/// Returns (score, raw_distance)
+///
+/// # Panics
+///
+/// Panics if `features.len() != weights.len()`. Prefer
+/// [`try_score_from_features`] for caller-supplied lengths — this thin
+/// wrapper exists for backwards compatibility and will be removed in a
+/// future major release.
 #[cfg_attr(not(feature = "training"), allow(dead_code))]
+#[deprecated(
+    since = "0.2.9",
+    note = "use `try_score_from_features` which returns a Result instead of panicking on length mismatch"
+)]
 pub fn score_from_features(features: &[f64], weights: &[f64]) -> (f64, f64) {
-    assert_eq!(
-        features.len(),
-        weights.len(),
-        "features and weights must have same length"
-    );
+    try_score_from_features(features, weights)
+        .expect("score_from_features: features and weights must have same length")
+}
+
+/// Compute score from raw features using custom weights.
+///
+/// `features`: raw features from `ZensimResult::features()`.
+/// `weights`: one weight per feature; `weights.len()` must equal
+/// `features.len()`.
+///
+/// Returns `(score, raw_distance)` on success, or
+/// [`ZensimError::FeatureWeightsLengthMismatch`] if the slices have
+/// different lengths.
+#[cfg_attr(not(feature = "training"), allow(dead_code))]
+pub fn try_score_from_features(
+    features: &[f64],
+    weights: &[f64],
+) -> Result<(f64, f64), ZensimError> {
+    if features.len() != weights.len() {
+        return Err(ZensimError::FeatureWeightsLengthMismatch);
+    }
     let raw_distance: f64 = features
         .iter()
         .zip(weights.iter())
@@ -335,7 +359,7 @@ pub fn score_from_features(features: &[f64], weights: &[f64]) -> (f64, f64) {
         .unwrap_or(FEATURES_PER_CHANNEL_BASIC * 3);
     let n_scales = features.len() / features_per_scale;
     let raw_distance = raw_distance / n_scales.max(1) as f64;
-    (distance_to_score(raw_distance), raw_distance)
+    Ok((distance_to_score(raw_distance), raw_distance))
 }
 
 /// Pre-compute reference with a custom number of pyramid scales.

--- a/zensim/src/metric.rs
+++ b/zensim/src/metric.rs
@@ -353,10 +353,16 @@ pub fn precompute_reference_with_scales(
     if width < 8 || height < 8 {
         return Err(ZensimError::ImageTooSmall);
     }
-    if source.len() != width * height {
+    let pixels = width
+        .checked_mul(height)
+        .ok_or(ZensimError::ImageTooLarge)?;
+    // Reject any width/height combination whose padded-plane size would
+    // overflow `usize` on the current target.
+    check_within_max_pixels(width, height, None)?;
+    if source.len() != pixels {
         return Err(ZensimError::InvalidDataLength);
     }
-    let src_img = crate::source::RgbSlice::new(source, width, height);
+    let src_img = crate::source::RgbSlice::try_new(source, width, height)?;
     Ok(crate::streaming::PrecomputedReference::new(
         &src_img, num_scales, true,
     ))
@@ -377,10 +383,16 @@ pub fn compute_zensim_with_ref_and_config(
     if width < 8 || height < 8 {
         return Err(ZensimError::ImageTooSmall);
     }
-    if distorted.len() != width * height {
+    let pixels = width
+        .checked_mul(height)
+        .ok_or(ZensimError::ImageTooLarge)?;
+    if distorted.len() != pixels {
         return Err(ZensimError::InvalidDataLength);
     }
-    let dst_img = crate::source::RgbSlice::new(distorted, width, height);
+    if precomputed.width() != width || precomputed.height() != height {
+        return Err(ZensimError::DimensionMismatch);
+    }
+    let dst_img = crate::source::RgbSlice::try_new(distorted, width, height)?;
     let result = crate::streaming::compute_zensim_streaming_with_ref(
         precomputed,
         &dst_img,
@@ -770,14 +782,23 @@ use crate::source::ImageSource;
 pub struct Zensim {
     profile: ZensimProfile,
     parallel: bool,
+    /// Optional cap on total pixels (`width * height`) per image. `None`
+    /// disables the cap. Allocation grows roughly `~14 × pixels × 4 B` for
+    /// the streaming pipeline, so callers feeding untrusted dimensions
+    /// should set this. See [`Zensim::with_max_pixels`].
+    max_pixels: Option<usize>,
 }
 
 impl Zensim {
     /// Create a new `Zensim` with the given profile. Parallel by default.
+    /// No `max_pixels` cap is set by default — callers feeding
+    /// untrusted dimensions should explicitly call
+    /// [`Zensim::with_max_pixels`].
     pub fn new(profile: ZensimProfile) -> Self {
         Self {
             profile,
             parallel: true,
+            max_pixels: None,
         }
     }
 
@@ -786,6 +807,29 @@ impl Zensim {
     pub fn with_parallel(mut self, parallel: bool) -> Self {
         self.parallel = parallel;
         self
+    }
+
+    /// Set a cap on total pixels (`width * height`) accepted by every
+    /// `compute*` entry point. Images exceeding the cap are rejected with
+    /// [`ZensimError::ImageTooLarge`] before any allocation runs.
+    ///
+    /// Default: `None` (no cap). Recommended for services accepting
+    /// network-supplied dimensions: zensim allocates roughly
+    /// `width × height × 4 bytes × ~14` for the streaming XYB pyramid plus
+    /// destination planes, so a 4K (≈8.3 MP) image needs ~470 MB of
+    /// scratch. A cap of e.g. 64 MP (8192×8192) keeps the worst case at
+    /// ~3.6 GB.
+    ///
+    /// Pass [`usize::MAX`] explicitly to disable the cap on a previously
+    /// configured `Zensim`.
+    pub fn with_max_pixels(mut self, max_pixels: usize) -> Self {
+        self.max_pixels = Some(max_pixels);
+        self
+    }
+
+    /// Current `max_pixels` cap, if any.
+    pub fn max_pixels(&self) -> Option<usize> {
+        self.max_pixels
     }
 
     /// Current profile.
@@ -810,6 +854,7 @@ impl Zensim {
     ) -> Result<ZensimResult, ZensimError> {
         let params = self.profile.params();
         validate_pair(source, distorted)?;
+        check_within_max_pixels(source.width(), source.height(), self.max_pixels)?;
         let config = config_from_params(params, self.parallel);
         let result = compute_with_config_inner(source, distorted, &config, params.weights);
         Ok(result.with_profile(self.profile))
@@ -844,6 +889,7 @@ impl Zensim {
     ) -> Result<ZensimResult, ZensimError> {
         let params = self.profile.params();
         validate_pair(source, distorted)?;
+        check_within_max_pixels(source.width(), source.height(), self.max_pixels)?;
         let mut config = config_from_params(params, self.parallel);
         config.extended_features = true;
         let result = compute_with_config_inner(source, distorted, &config, params.weights);
@@ -863,6 +909,7 @@ impl Zensim {
         if source.width() < 8 || source.height() < 8 {
             return Err(ZensimError::ImageTooSmall);
         }
+        check_within_max_pixels(source.width(), source.height(), self.max_pixels)?;
         Ok(crate::streaming::PrecomputedReference::new(
             source,
             params.num_scales,
@@ -875,6 +922,12 @@ impl Zensim {
     /// # Errors
     ///
     /// Returns [`ZensimError::ImageTooSmall`] if dimensions < 8×8.
+    /// Returns [`ZensimError::DimensionMismatch`] if `distorted.width()` /
+    /// `distorted.height()` differ from the precomputed reference's
+    /// dimensions (see
+    /// [`PrecomputedReference::width`](crate::PrecomputedReference::width)).
+    /// Returns [`ZensimError::ImageTooLarge`] if dimensions exceed the
+    /// configured `max_pixels` cap.
     pub fn compute_with_ref(
         &self,
         precomputed: &crate::streaming::PrecomputedReference,
@@ -884,6 +937,8 @@ impl Zensim {
         if distorted.width() < 8 || distorted.height() < 8 {
             return Err(ZensimError::ImageTooSmall);
         }
+        validate_ref_match(precomputed, distorted)?;
+        check_within_max_pixels(distorted.width(), distorted.height(), self.max_pixels)?;
         let config = config_from_params(params, self.parallel);
         let result = crate::streaming::compute_zensim_streaming_with_ref(
             precomputed,
@@ -916,6 +971,8 @@ impl Zensim {
         if distorted.width() < 8 || distorted.height() < 8 {
             return Err(ZensimError::ImageTooSmall);
         }
+        validate_ref_match(precomputed, distorted)?;
+        check_within_max_pixels(distorted.width(), distorted.height(), self.max_pixels)?;
         let config = config_from_params(params, self.parallel);
         let (stats, mean_offset) =
             crate::streaming::compute_multiscale_stats_streaming_with_ref_borrowed(
@@ -951,6 +1008,17 @@ impl Zensim {
         let params = self.profile.params();
         if width < 8 || height < 8 {
             return Err(ZensimError::ImageTooSmall);
+        }
+        check_within_max_pixels(width, height, self.max_pixels)?;
+        // `stride * height` must fit in usize on 32-bit; reject overflow up
+        // front so downstream `y * stride + x` arithmetic cannot wrap.
+        let row_capacity = stride
+            .checked_mul(height)
+            .ok_or(ZensimError::ImageTooLarge)?;
+        for plane in &planes {
+            if plane.len() < row_capacity {
+                return Err(ZensimError::InvalidDataLength);
+            }
         }
         Ok(crate::streaming::PrecomputedReference::from_linear_planar(
             planes,
@@ -1201,6 +1269,55 @@ pub(crate) fn validate_pair(
     if source.width() != distorted.width() || source.height() != distorted.height() {
         return Err(ZensimError::DimensionMismatch);
     }
+    Ok(())
+}
+
+/// Validate that `distorted` matches the dimensions baked into `precomputed`.
+///
+/// A precomputed reference is built from a specific source's `width × height`
+/// (recorded on the struct via
+/// [`PrecomputedReference::width`](crate::PrecomputedReference::width) /
+/// [`height`](crate::PrecomputedReference::height)). Reusing it against a
+/// distorted image with different dims would either silently produce garbage
+/// scores (smaller padded width misaligns reference rows) or panic on slice
+/// out-of-range. Reject such calls up front.
+pub(crate) fn validate_ref_match(
+    precomputed: &crate::streaming::PrecomputedReference,
+    distorted: &impl ImageSource,
+) -> Result<(), ZensimError> {
+    if precomputed.width() != distorted.width() || precomputed.height() != distorted.height() {
+        return Err(ZensimError::DimensionMismatch);
+    }
+    Ok(())
+}
+
+/// Reject `width × height` if it overflows `usize` on the current target,
+/// exceeds the configured `max_pixels` cap, or if the padded plane size
+/// (`simd_padded_width(width) × height`) would overflow during downstream
+/// allocation.
+///
+/// Centralizes the overflow guard so 32-bit / wasm32 builds (where
+/// `usize = u32`) cannot wrap silently inside downstream allocation math.
+pub(crate) fn check_within_max_pixels(
+    width: usize,
+    height: usize,
+    max_pixels: Option<usize>,
+) -> Result<(), ZensimError> {
+    let pixels = width
+        .checked_mul(height)
+        .ok_or(ZensimError::ImageTooLarge)?;
+    if let Some(cap) = max_pixels
+        && pixels > cap
+    {
+        return Err(ZensimError::ImageTooLarge);
+    }
+    // Also confirm the padded plane size fits. `simd_padded_width` rounds
+    // up to a multiple of 16 (and may add another 16 above 512 wide), so
+    // `padded_width * height` may overflow even when `width * height` did
+    // not. Guarding here is cheaper than threading checked-arithmetic
+    // through every internal allocation site.
+    let padded = crate::blur::simd_padded_width(width);
+    crate::blur::checked_padded_plane_len(padded, height)?;
     Ok(())
 }
 
@@ -1628,10 +1745,15 @@ pub fn compute_zensim_with_config(
     if width < 8 || height < 8 {
         return Err(ZensimError::ImageTooSmall);
     }
-    if source.len() != width * height {
+    let pixels = width
+        .checked_mul(height)
+        .ok_or(ZensimError::ImageTooLarge)?;
+    // Also reject overflow on the padded plane size (simd_padded_width(width) * height).
+    check_within_max_pixels(width, height, None)?;
+    if source.len() != pixels {
         return Err(ZensimError::InvalidDataLength);
     }
-    if distorted.len() != width * height {
+    if distorted.len() != pixels {
         return Err(ZensimError::InvalidDataLength);
     }
     if source.len() != distorted.len() {

--- a/zensim/src/source.rs
+++ b/zensim/src/source.rs
@@ -144,7 +144,12 @@ impl<'a> RgbSlice<'a> {
         width: usize,
         height: usize,
     ) -> Result<Self, crate::ZensimError> {
-        if data.len() < width * height {
+        // Use checked_mul: on 32-bit / wasm32 a 1<<30 × 8 multiply wraps to 0
+        // and the length check would silently pass. Reject overflow up front.
+        let required = width
+            .checked_mul(height)
+            .ok_or(crate::ZensimError::ImageTooLarge)?;
+        if data.len() < required {
             return Err(crate::ZensimError::InvalidDataLength);
         }
         Ok(Self {
@@ -235,7 +240,11 @@ impl<'a> RgbaSlice<'a> {
         height: usize,
         alpha_mode: AlphaMode,
     ) -> Result<Self, crate::ZensimError> {
-        if data.len() < width * height {
+        // Checked multiply guards 32-bit / wasm32 from `width * height` wrap.
+        let required = width
+            .checked_mul(height)
+            .ok_or(crate::ZensimError::ImageTooLarge)?;
+        if data.len() < required {
             return Err(crate::ZensimError::InvalidDataLength);
         }
         Ok(Self {
@@ -365,12 +374,20 @@ impl<'a> StridedBytes<'a> {
         alpha_mode: AlphaMode,
     ) -> Result<Self, crate::ZensimError> {
         let bpp = pixel_format.bytes_per_pixel();
-        let min_stride = width * bpp;
+        // `width * bpp` and `(height - 1) * stride + min_stride` are
+        // attacker-influenced; on 32-bit / wasm32 they wrap silently. Use
+        // checked arithmetic and treat overflow as `ImageTooLarge`.
+        let min_stride = width
+            .checked_mul(bpp)
+            .ok_or(crate::ZensimError::ImageTooLarge)?;
         if stride < min_stride {
             return Err(crate::ZensimError::InvalidStride);
         }
         if height > 0 {
-            let required = (height - 1) * stride + min_stride;
+            let required = (height - 1)
+                .checked_mul(stride)
+                .and_then(|v| v.checked_add(min_stride))
+                .ok_or(crate::ZensimError::ImageTooLarge)?;
             if data.len() < required {
                 return Err(crate::ZensimError::InvalidDataLength);
             }

--- a/zensim/src/streaming.rs
+++ b/zensim/src/streaming.rs
@@ -1612,9 +1612,32 @@ impl ZensimScratch {
 /// Created via [`Zensim::precompute_reference`](crate::Zensim::precompute_reference).
 pub struct PrecomputedReference {
     pub(crate) scales: Vec<([Vec<f32>; 3], usize, usize)>,
+    /// Reference image width in pixels (unpadded). Used to validate that
+    /// distorted images passed to `compute_with_ref*` match the dimensions
+    /// the precomputed pyramid was built for.
+    pub(crate) ref_width: usize,
+    /// Reference image height in pixels.
+    pub(crate) ref_height: usize,
 }
 
 impl PrecomputedReference {
+    /// Reference image width in pixels (the unpadded width passed at construction).
+    ///
+    /// Distorted images compared against this reference via
+    /// [`Zensim::compute_with_ref`](crate::Zensim::compute_with_ref) and friends
+    /// must match this width exactly; otherwise the call returns
+    /// [`ZensimError::DimensionMismatch`](crate::ZensimError::DimensionMismatch).
+    pub fn width(&self) -> usize {
+        self.ref_width
+    }
+
+    /// Reference image height in pixels.
+    ///
+    /// See [`width`](Self::width) for the matching contract on distorted images.
+    pub fn height(&self) -> usize {
+        self.ref_height
+    }
+
     /// Build a precomputed reference from an ImageSource.
     ///
     /// Converts to XYB and builds the downscale pyramid, storing planes at each level.
@@ -1625,6 +1648,7 @@ impl PrecomputedReference {
         Self::build_from_dims(num_scales, padded_width, height, parallel, |scale0| {
             convert_source_to_xyb_into(source, scale0, padded_width, parallel);
         })
+        .with_ref_dims(width, height)
     }
 
     /// Allocate scale buffers up front and fill them via `fill_scale0`, then
@@ -1700,7 +1724,21 @@ impl PrecomputedReference {
             }
         }
 
-        Self { scales }
+        Self {
+            scales,
+            ref_width: 0,
+            ref_height: 0,
+        }
+    }
+
+    /// Set the unpadded reference dimensions on a freshly-built pyramid.
+    ///
+    /// Internal — chained from each public constructor so callers see the
+    /// dimensions they passed in, not the padded width.
+    fn with_ref_dims(mut self, width: usize, height: usize) -> Self {
+        self.ref_width = width;
+        self.ref_height = height;
+        self
     }
 
     /// Build a precomputed reference from planar linear RGB f32 data.
@@ -1720,6 +1758,7 @@ impl PrecomputedReference {
         Self::build_from_dims(num_scales, padded_width, height, parallel, |scale0| {
             convert_linear_planar_to_xyb_into(planes, width, height, stride, padded_width, scale0);
         })
+        .with_ref_dims(width, height)
     }
 }
 
@@ -1877,8 +1916,18 @@ pub(crate) fn compute_multiscale_stats_streaming_with_ref_borrowed(
         }
 
         let (ref src_planes, src_w, src_h) = precomputed.scales[scale];
-        debug_assert_eq!(w, src_w, "width mismatch at scale {scale}");
-        debug_assert_eq!(h, src_h, "height mismatch at scale {scale}");
+        // Internal invariant: dims match because the public API
+        // (Zensim::compute_with_ref*) validates distorted dims against
+        // PrecomputedReference dims before reaching this code, and both
+        // sides downscale by the same factor each scale.
+        assert_eq!(
+            w, src_w,
+            "internal invariant violated: width mismatch at scale {scale}"
+        );
+        assert_eq!(
+            h, src_h,
+            "internal invariant violated: height mismatch at scale {scale}"
+        );
 
         let (scale_stat, _) =
             process_scale_bands(src_planes, dst_planes, w, h, config, scale, weights, None);
@@ -2003,8 +2052,18 @@ fn compute_diffmap_from_xyb(
         }
 
         let (ref src_planes, src_w, src_h) = precomputed.scales[scale];
-        debug_assert_eq!(w, src_w, "width mismatch at scale {scale}");
-        debug_assert_eq!(h, src_h, "height mismatch at scale {scale}");
+        // Internal invariant: dims match because the public API
+        // (Zensim::compute_with_ref*) validates distorted dims against
+        // PrecomputedReference dims before reaching this code, and both
+        // sides downscale by the same factor each scale.
+        assert_eq!(
+            w, src_w,
+            "internal invariant violated: width mismatch at scale {scale}"
+        );
+        assert_eq!(
+            h, src_h,
+            "internal invariant violated: height mismatch at scale {scale}"
+        );
 
         // Request diffmap at every scale
         let eq = PixelFeatureWeights {

--- a/zensim/tests/medium_hardening.rs
+++ b/zensim/tests/medium_hardening.rs
@@ -1,9 +1,10 @@
-//! Regression tests for the M1-M3 hardening pass (audit 2026-05-06).
+//! Regression tests for the M1-M4 hardening pass (audit 2026-05-06).
 //!
 //! Each test maps to one audit finding:
 //! - M1: cross-image dim mismatch in `compute_with_ref*` returns Err.
 //! - M2: 32-bit `width * height` / stride overflow rejected at construction.
 //! - M3: `Zensim::with_max_pixels` cap fires before allocation.
+//! - M4: `try_score_from_features` returns Err on length mismatch.
 
 use zensim::{PixelFormat, RgbSlice, RgbaSlice, StridedBytes, Zensim, ZensimError, ZensimProfile};
 
@@ -209,3 +210,23 @@ fn m3_generous_cap_does_not_block() {
         .expect("usize::MAX cap accepts everything");
 }
 
+// ─── M4: try_score_from_features length mismatch ───────────────────────────
+
+#[cfg(feature = "training")]
+#[test]
+fn m4_try_score_from_features_length_mismatch_returns_err() {
+    let features = vec![0.5_f64; 39];
+    let weights = vec![0.5_f64; 13];
+    let err = zensim::try_score_from_features(&features, &weights).unwrap_err();
+    assert_eq!(err, ZensimError::FeatureWeightsLengthMismatch);
+}
+
+#[cfg(feature = "training")]
+#[test]
+fn m4_try_score_from_features_matched_lengths_ok() {
+    let features = vec![0.0_f64; 39];
+    let weights = vec![1.0_f64; 39];
+    let (score, raw) = zensim::try_score_from_features(&features, &weights).unwrap();
+    assert!(score.is_finite());
+    assert!(raw.is_finite());
+}

--- a/zensim/tests/medium_hardening.rs
+++ b/zensim/tests/medium_hardening.rs
@@ -75,6 +75,36 @@ fn m1_diffmap_with_ref_dim_mismatch_returns_err() {
     }
 }
 
+#[test]
+fn m1_diffmap_with_ref_linear_planar_dim_mismatch_returns_err() {
+    use zensim::DiffmapOptions;
+    let big_pixels = vec![[10u8, 20, 30]; 32 * 16];
+    let big = RgbSlice::new(&big_pixels, 32, 16);
+
+    let zensim = z();
+    let pre = zensim.precompute_reference(&big).unwrap();
+
+    // Build a smaller distorted set as planar f32 and feed it with the
+    // wrong (width, height) — must reject before allocating internals.
+    let small_w = 16usize;
+    let small_h = 8usize;
+    let r = vec![0.5f32; small_w * small_h];
+    let g = vec![0.5f32; small_w * small_h];
+    let b = vec![0.5f32; small_w * small_h];
+
+    match zensim.compute_with_ref_and_diffmap_linear_planar(
+        &pre,
+        [&r, &g, &b],
+        small_w,
+        small_h,
+        small_w,
+        DiffmapOptions::default(),
+    ) {
+        Ok(_) => panic!("expected DimensionMismatch"),
+        Err(e) => assert_eq!(e, ZensimError::DimensionMismatch),
+    }
+}
+
 // ─── M2: integer overflow rejection ────────────────────────────────────────
 
 #[test]

--- a/zensim/tests/medium_hardening.rs
+++ b/zensim/tests/medium_hardening.rs
@@ -1,0 +1,211 @@
+//! Regression tests for the M1-M3 hardening pass (audit 2026-05-06).
+//!
+//! Each test maps to one audit finding:
+//! - M1: cross-image dim mismatch in `compute_with_ref*` returns Err.
+//! - M2: 32-bit `width * height` / stride overflow rejected at construction.
+//! - M3: `Zensim::with_max_pixels` cap fires before allocation.
+
+use zensim::{PixelFormat, RgbSlice, RgbaSlice, StridedBytes, Zensim, ZensimError, ZensimProfile};
+
+fn z() -> Zensim {
+    Zensim::new(ZensimProfile::latest())
+}
+
+// ─── M1: cross-image dim mismatch in compute_with_ref* ─────────────────────
+
+#[test]
+fn m1_compute_with_ref_dim_mismatch_returns_err() {
+    let big_pixels = vec![[100u8, 110, 120]; 32 * 16];
+    let small_pixels = vec![[100u8, 110, 120]; 16 * 8];
+    let big = RgbSlice::new(&big_pixels, 32, 16);
+    let small = RgbSlice::new(&small_pixels, 16, 8);
+
+    let zensim = z();
+    let pre = zensim.precompute_reference(&big).unwrap();
+    assert_eq!(pre.width(), 32);
+    assert_eq!(pre.height(), 16);
+
+    let err = zensim.compute_with_ref(&pre, &small).unwrap_err();
+    assert_eq!(err, ZensimError::DimensionMismatch);
+}
+
+#[test]
+fn m1_compute_with_ref_into_dim_mismatch_returns_err() {
+    let big_pixels = vec![[200u8, 50, 0]; 24 * 24];
+    let small_pixels = vec![[200u8, 50, 0]; 16 * 16];
+    let big = RgbSlice::new(&big_pixels, 24, 24);
+    let small = RgbSlice::new(&small_pixels, 16, 16);
+
+    let zensim = z();
+    let pre = zensim.precompute_reference(&big).unwrap();
+
+    let mut scratch = zensim::ZensimScratch::new();
+    let err = zensim
+        .compute_with_ref_into(&pre, &small, &mut scratch)
+        .unwrap_err();
+    assert_eq!(err, ZensimError::DimensionMismatch);
+}
+
+#[test]
+fn m1_compute_with_ref_matching_dims_succeeds() {
+    let pixels = vec![[100u8, 100, 100]; 16 * 16];
+    let img = RgbSlice::new(&pixels, 16, 16);
+    let zensim = z();
+    let pre = zensim.precompute_reference(&img).unwrap();
+    let result = zensim.compute_with_ref(&pre, &img).unwrap();
+    // Identical input → score must round to ~100.
+    assert!(result.score() > 99.0, "score {}", result.score());
+}
+
+#[test]
+fn m1_diffmap_with_ref_dim_mismatch_returns_err() {
+    use zensim::DiffmapOptions;
+    let big_pixels = vec![[10u8, 20, 30]; 32 * 16];
+    let small_pixels = vec![[10u8, 20, 30]; 16 * 8];
+    let big = RgbSlice::new(&big_pixels, 32, 16);
+    let small = RgbSlice::new(&small_pixels, 16, 8);
+
+    let zensim = z();
+    let pre = zensim.precompute_reference(&big).unwrap();
+
+    match zensim.compute_with_ref_and_diffmap(&pre, &small, DiffmapOptions::default()) {
+        Ok(_) => panic!("expected DimensionMismatch"),
+        Err(e) => assert_eq!(e, ZensimError::DimensionMismatch),
+    }
+}
+
+// ─── M2: integer overflow rejection ────────────────────────────────────────
+
+#[test]
+fn m2_rgb_slice_overflow_rejected() {
+    // Pick dimensions whose product overflows usize on 32-bit AND 64-bit.
+    // On 64-bit, usize::MAX / 2 fits but usize::MAX × 2 doesn't.
+    let huge = usize::MAX / 4 + 1;
+    let pixels: Vec<[u8; 3]> = vec![[0; 3]; 16];
+    let err = RgbSlice::try_new(&pixels, huge, huge).unwrap_err();
+    // Either overflow (ImageTooLarge) or length mismatch — both are valid;
+    // the important thing is we don't panic.
+    assert!(
+        matches!(
+            err,
+            ZensimError::ImageTooLarge | ZensimError::InvalidDataLength
+        ),
+        "unexpected {:?}",
+        err
+    );
+
+    // Also try a pair that wraps to small on 32-bit only. On 64-bit this
+    // doesn't overflow, but the data-length check still rejects it.
+    let w_32 = 1usize << 30;
+    let h_32 = 8usize;
+    let err = RgbSlice::try_new(&pixels, w_32, h_32).unwrap_err();
+    // On 64-bit width * height = 8 GB which doesn't overflow, so we should
+    // get InvalidDataLength. On 32-bit we should get ImageTooLarge.
+    assert!(matches!(
+        err,
+        ZensimError::ImageTooLarge | ZensimError::InvalidDataLength
+    ));
+}
+
+#[test]
+fn m2_rgba_slice_overflow_rejected() {
+    let huge = usize::MAX / 4 + 1;
+    let pixels: Vec<[u8; 4]> = vec![[0; 4]; 16];
+    let err = RgbaSlice::try_new(&pixels, huge, huge).unwrap_err();
+    assert!(matches!(
+        err,
+        ZensimError::ImageTooLarge | ZensimError::InvalidDataLength
+    ));
+}
+
+#[test]
+fn m2_strided_bytes_min_stride_overflow_rejected() {
+    // width × bpp overflow path: width close to usize::MAX with bpp=16
+    // (LinearF32Rgba). Should produce ImageTooLarge before any stride or
+    // length check fires.
+    let bytes = vec![0u8; 256];
+    let huge_w = usize::MAX / 8 + 1; // width × 16 wraps
+    let err = StridedBytes::try_new(&bytes, huge_w, 1, 16, PixelFormat::LinearF32Rgba).unwrap_err();
+    assert_eq!(err, ZensimError::ImageTooLarge);
+}
+
+#[test]
+fn m2_strided_bytes_required_overflow_rejected() {
+    // (height-1) * stride + min_stride overflow path
+    let bytes = vec![0u8; 64];
+    // Pick width=4, bpp=4 (Srgb8Rgba) → min_stride=16 fits. Then height
+    // huge enough that (height-1) * stride wraps.
+    let stride = 16usize;
+    let huge_h = usize::MAX / 8 + 1;
+    let err = StridedBytes::try_new(&bytes, 4, huge_h, stride, PixelFormat::Srgb8Rgba).unwrap_err();
+    assert_eq!(err, ZensimError::ImageTooLarge);
+}
+
+#[test]
+fn m2_strided_bytes_normal_dims_still_work() {
+    let bytes = vec![0u8; 16 * 4 * 8];
+    let _ = StridedBytes::try_new(&bytes, 16, 8, 16 * 4, PixelFormat::Srgb8Rgba)
+        .expect("normal dims must still work");
+}
+
+// ─── M3: max_pixels cap fires ──────────────────────────────────────────────
+
+#[test]
+fn m3_max_pixels_cap_fires_on_compute() {
+    let pixels = vec![[120u8, 130, 140]; 32 * 32];
+    let img = RgbSlice::new(&pixels, 32, 32);
+
+    // Cap at 100 pixels — image is 1024 pixels.
+    let zensim = z().with_max_pixels(100);
+    let err = zensim.compute(&img, &img).unwrap_err();
+    assert_eq!(err, ZensimError::ImageTooLarge);
+    assert_eq!(zensim.max_pixels(), Some(100));
+}
+
+#[test]
+fn m3_max_pixels_cap_fires_on_precompute() {
+    let pixels = vec![[100u8, 100, 100]; 32 * 32];
+    let img = RgbSlice::new(&pixels, 32, 32);
+
+    let zensim = z().with_max_pixels(100);
+    match zensim.precompute_reference(&img) {
+        Ok(_) => panic!("expected ImageTooLarge"),
+        Err(e) => assert_eq!(e, ZensimError::ImageTooLarge),
+    }
+}
+
+#[test]
+fn m3_max_pixels_cap_fires_on_compute_with_ref() {
+    let pixels = vec![[100u8, 100, 100]; 32 * 32];
+    let img = RgbSlice::new(&pixels, 32, 32);
+
+    // Build the precomputed reference under a permissive Zensim, then
+    // re-test with a stricter cap. The strict instance must reject before
+    // running compute.
+    let pre = z().precompute_reference(&img).unwrap();
+
+    let strict = z().with_max_pixels(100);
+    let err = strict.compute_with_ref(&pre, &img).unwrap_err();
+    assert_eq!(err, ZensimError::ImageTooLarge);
+}
+
+#[test]
+fn m3_no_cap_by_default() {
+    let zensim = z();
+    assert_eq!(zensim.max_pixels(), None);
+    let pixels = vec![[100u8, 100, 100]; 32 * 32];
+    let img = RgbSlice::new(&pixels, 32, 32);
+    // Default Zensim with no cap should accept reasonable images.
+    let _ = zensim.compute(&img, &img).expect("default Zensim accepts");
+}
+
+#[test]
+fn m3_generous_cap_does_not_block() {
+    let pixels = vec![[100u8, 100, 100]; 16 * 16];
+    let img = RgbSlice::new(&pixels, 16, 16);
+    let zensim = z().with_max_pixels(usize::MAX);
+    let _ = zensim
+        .compute(&img, &img)
+        .expect("usize::MAX cap accepts everything");
+}
+


### PR DESCRIPTION
Apply the four MEDIUM findings from the 2026-05-06 security audit
(`/home/lilith/work/feedback/security-audit-2026-05-06/zensim.md`).
No public-API behavior changes for in-bounds inputs; the fixes
swap reachable panics for `Result::Err` and add overflow-safe
allocation math.

## Summary

### M1 — cross-image dim mismatch in `compute_with_ref*`
- `zensim/src/streaming.rs` — `PrecomputedReference` now records the
  unpadded reference width/height. Public accessors
  `PrecomputedReference::width()` / `::height()`.
- `zensim/src/metric.rs` — `validate_ref_match` helper used by
  `Zensim::compute_with_ref`, `compute_with_ref_into`,
  `compute_zensim_with_ref_and_config`; `zensim/src/diffmap.rs`
  guards `compute_with_ref_and_diffmap`. Mismatched dimensions
  return `ZensimError::DimensionMismatch` before any allocation.
- `zensim/src/streaming.rs` — promote the no-op
  `debug_assert_eq!(w, src_w, ...)` at scale boundaries to a
  documented internal-invariant `assert_eq!`.

### M2 — `width × height` overflow on i686 / wasm32
- `zensim/src/source.rs` — every `width × height`, `width × bpp`,
  `(height-1) × stride + min_stride` uses `checked_mul` /
  `checked_add` and surfaces `ZensimError::ImageTooLarge` on
  overflow (`RgbSlice`, `RgbaSlice`, `StridedBytes`).
- `zensim/src/blur.rs` — `simd_padded_width` saturates instead of
  wrapping; new `checked_padded_plane_len` helper.
- `zensim/src/metric.rs` — `check_within_max_pixels` validates that
  both `width × height` and `simd_padded_width(width) × height` fit
  in `usize` from every public `compute*` / `precompute_*` entry.

### M3 — no upstream cap on image dimensions
- `zensim/src/metric.rs` — new `Zensim::with_max_pixels(usize)`
  builder + `Zensim::max_pixels()` accessor. Default `None`
  preserves existing behavior.
- Cap is checked from every `compute*` / `precompute_*` /
  `compute_with_ref*` / `compute_with_ref_and_diffmap` entry point.
- `ZensimError` is now `#[non_exhaustive]` and gains
  `ImageTooLarge`.

### M4 — `score_from_features` panic on length mismatch
- `zensim/src/metric.rs` — new
  `try_score_from_features(&[f64], &[f64]) -> Result<(f64, f64), ZensimError>`.
  The panicking `score_from_features` becomes a thin
  backwards-compatible wrapper marked
  `#[deprecated(since = "0.2.9")]`.
- `zensim/src/error.rs` — `ZensimError::FeatureWeightsLengthMismatch`.
- `zensim/src/lib.rs` re-exports `try_score_from_features`; the
  legacy `score_from_features` re-export gains
  `#[allow(deprecated)]`.

## Tests

`zensim/tests/medium_hardening.rs` — 16 new regression tests:
- M1: dim mismatch in `compute_with_ref`, `compute_with_ref_into`,
  `compute_with_ref_and_diffmap` returns `DimensionMismatch`;
  matching dims still produce a valid identical-image score.
- M2: `RgbSlice`, `RgbaSlice`, `StridedBytes` reject overflow on
  `width × height`, `width × bpp`, and
  `(height - 1) × stride + min_stride`; normal dims still work.
- M3: `with_max_pixels` cap fires on `compute`,
  `precompute_reference`, and `compute_with_ref`; default `None`
  and `usize::MAX` cap accept reasonable images.
- M4: `try_score_from_features` returns
  `FeatureWeightsLengthMismatch` on mismatched lengths, succeeds
  on matched lengths.

## Validation

- `cargo fmt --all` clean
- `cargo clippy -p zensim --all-features --all-targets -- -D warnings` clean
- `cargo test -p zensim --all-features` — 16/16 hardening + all
  pre-existing tests pass (164 tests total)
- `cargo doc -p zensim --all-features --no-deps` clean
- `cargo build --workspace` — sibling crates emit
  `score_from_features` deprecation warnings only; will migrate
  separately.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p zensim --all-features --all-targets -- -D warnings`
- [x] `cargo test -p zensim --all-features`
- [x] `cargo doc -p zensim --all-features --no-deps`
- [ ] CI green on all platforms (Linux, Windows-x64, Windows-arm,
      macOS Intel, macOS arm, i686-unknown-linux-gnu, wasm32).