### PR TITLE
feat(v_next): unified parquet pipeline + score-quality analyzer + CID22 paper notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ Cargo.toml.original.txt
 fuzz-*.log
 
 .workongoing
+
+# Python
+__pycache__/
+*.pyc

--- a/docs/CID22_PAPER_NOTES_2026-05-07.md
+++ b/docs/CID22_PAPER_NOTES_2026-05-07.md
@@ -1,0 +1,188 @@
+# CID22 paper insights for zensim v_next
+
+**Source:** Sneyers, Ben Baruch, Vaxman (Cloudinary), 2023.
+"AIC-3 Contribution from Cloudinary: CID22"
+JPEG WG1 document `wg1m99012-ICQ-AIC3_Contribution_Cloudinary_CID22.pdf`
+Mirror: `/mnt/v/zen/zensim-training/2026-05-07/papers/CID22_wg1m99012.pdf`
+
+30 pages. Read in full 2026-05-07. Below are the load-bearing findings
+for our v_next zensim training cycle.
+
+## Dataset facts (for evaluation)
+
+- **CID22** = Cloudinary Image Dataset '22 — **22,153 distorted images**
+  from **250 pristine 512×512 references**, 6 codec classes, 8–11 q
+  settings each.
+- **1.4 million human opinions** combining two protocols:
+  - **TSBPC** (Triple Stimulus Boosted Pairwise Comparison) — `(R, A, B)` pick which
+    distortion of `R` is better. Generates RMOS (Elo-style ranking, [0,1]).
+  - **DSBQS** (Double Stimulus Boosted Quality Scale) — single image with toggle to
+    reference, 0–10 scale. Anchor MCOS scores.
+- **MCOS** = bias-corrected mean opinion score combining DSBQS anchors + TSBPC
+  relative rankings, on **0–100** scale.
+- 91.7% of CID22 images have MCOS ≥ 50 (medium quality or better) — focused on
+  the web/practical-fidelity range.
+- **49 reference images held out** from the SSIMULACRA 2 weight tuning — these
+  4,292 distorted pairs are the only fully-disjoint CID22 evaluation set.
+  The other 201 references were used to tune SSIMULACRA 2 weights.
+
+## Quality scale alignment (Table 5)
+
+The **canonical quality scale** for v_next (CID22 MCOS) — match this in
+zensim output:
+
+| Reference quality | CID22 MCOS | SSIMULACRA 2 | PSNR-HVS | MS-SSIM ×100 | VMAF | DSSIM ×1000 | BA 3-norm |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| medium quality | 50 | 50 | 35 | 98 | 83 | 8 | 2.5 |
+| high quality | 65 | 65 | 40 | 99.2 | 91 | 3.5 | 1.6 |
+| visually lossless | 90 | 90 | 50 | 99.8 | 96 | 1 | 0.5 |
+
+**SSIMULACRA 2 maps 1:1 to MCOS** — same numerical scale. This is
+why we keep `score_ssim2` as the v_next training target (and why
+analyze_score_quality.py flagged the +7..+11 zensim-vs-ssim2 bias as
+real calibration drift).
+
+## Metric performance on CID22 — absolute scores (Table 3, all 250 refs)
+
+| Metric | KRCC | **SROCC** | PCC |
+|---|---|:---:|---|
+| SSIMULACRA 2 | 0.6934 | **0.882** | 0.8601 |
+| Butteraugli 2-norm | 0.6575 | 0.8455 | 0.8089 |
+| Butteraugli 3-norm | 0.6547 | 0.8387 | 0.7903 |
+| DSSIM | 0.6428 | 0.8399 | 0.7813 |
+| VMAF | 0.6176 | 0.8163 | 0.7799 |
+| FSIM | 0.6089 | 0.8005 | 0.7676 |
+| PSNR-HVS | 0.6076 | 0.8100 | 0.7559 |
+| BA max-norm | 0.5843 | 0.7738 | 0.7074 |
+| SSIM | 0.5628 | 0.7577 | 0.7005 |
+| MS-SSIM | 0.5596 | 0.7551 | 0.7035 |
+| LPIPS | 0.5417 | 0.7316 | 0.6932 |
+
+**SSIMULACRA 2 absolutely wins on CID22**, but with the caveat that
+201/250 refs were in its training set. On the 49 held-out refs it's
+KRCC 0.7033 / SRCC 0.88541 / PCC 0.87448 / MAE 4.97 — still the best.
+
+## Metric performance — pairwise differences (Table 6)
+
+When you control for reference image (compare two distortions of the
+same source — exactly the kind of question encoder development asks),
+correlations are *much higher* and SSIM2 is even more dominant:
+
+| Metric | KRCC | SROCC | PCC |
+|---|---|:---:|---|
+| SSIMULACRA 2 | 0.7536 | **0.9210** | 0.9085 |
+| DSSIM | 0.7203 | 0.9019 | 0.8352 |
+| SSIMULACRA 1 | 0.7059 | 0.8915 | 0.8399 |
+| BA 2-norm | 0.6852 | 0.8688 | 0.8422 |
+| FSIM | 0.6828 | 0.8656 | 0.8411 |
+| BA 3-norm | 0.6787 | 0.8610 | 0.8252 |
+
+**Implication for v_next training loss:** RankNet (pairwise hinge,
+within-source) dramatically outperforms MSE-against-absolute-MOS as a
+supervisor signal. The current `train_v_next_mlp.py` already supports
+this — keep `--loss mse_rank` with `--rank-weight 0.5`.
+
+## Recommended quality ranges per metric (Table 7, summarized)
+
+What zensim is asked to do well at (web compression):
+
+| Metric | very low | low | medium | high | very high | visually lossless |
+|---|---|---|---|---|---|---|
+| **SSIMULACRA 2** | mediocre | good | very good | very good | very good | very good |
+| **BA 3-norm** | very poor | poor | mediocre | good | very good | very good |
+| DSSIM | good | very good | very good | good | good | good |
+| MS-SSIM | very good | good | mediocre | mediocre | poor | poor |
+| VMAF | good | mediocre | good | good | mediocre | mediocre |
+| PSNR-HVS | very poor | poor | good | mediocre | good | good |
+| SSIM | good | good | mediocre | mediocre | poor | poor |
+
+**Implication for v_next:** SSIMULACRA 2 is the right *primary* target.
+But for the `q < 50` band where SSIM2 falls to "mediocre" / "good", a
+multi-task supervision adding DSSIM (best in low-q) or BA-3-norm (best
+in very-high-q) would fill the tails. Our unified parquet has all four
+target columns; lock training to `--target ssim2` for the main bake and
+plan a complementary `--target multi {ssim2:1.0, dssim:0.4, ba_p3:0.3}`
+ablation as a follow-up.
+
+## SSIMULACRA 2 architecture (paper p. 26, used for tractability comparisons)
+
+- **6 scales** (1:1 to 1:32), downsampling in **linear RGB**
+- Score computed in **XYB color space**
+- 3 SSIM error maps + 2 asymmetric error maps (ringing, smoothing) per scale
+- 54 maps total × 2 aggregation norms (L1, L4) = **108 sub-scores**
+- Final = weighted sum, weights optimized on 201 CID22 references
+
+zensim today: 4 scales × 13 basic + 6 peak + (6 masked + 4 psycho) extended =
+228 (basic + peaks) or 348 (extended) features, weighted via 228-element
+LINEAR_WEIGHTS_PREVIEW (V0_2) or 228 → 64 LeakyReLU → 1 MLP (PR #24 V0_4).
+
+**Implication:** SSIMULACRA 2's choice of 6 scales is more than zensim's 4.
+That extra scale headroom would help most on **multi-scale invariance**
+(handoff TODO §4.3) — at large source dimensions zensim's 4-scale pyramid
+runs out of low-frequency context. **Add 2 more scales for V0_5/V_NEXT**
+or note this as a known limitation.
+
+## Methodology notes useful for our own training
+
+- **Honeypot screening + bias correction** — CID22 discarded ~14.7% of
+  TSBPC sessions for low-honeypot-agreement; ~11% of DSBQS sessions for
+  failed score gating. We get this for free since our supervisor is
+  ssim2/butteraugli, but it argues for **excluding rows where
+  butteraugli and ssim2 disagree by > 5σ** (pure noise) before training.
+
+- **Forced monotonicity** — the paper added 200 dummy "higher bitrate is
+  better" opinions per same-codec pair to smooth Elo rankings. Our
+  monotonicity_violations.tsv (71,115 cases) shows zensim does NOT
+  enforce this. Adding a **monotonicity penalty** to v_next's loss
+  (sort by q within a (image, codec, knobs) curve, penalize backward
+  steps) would directly fix our biggest score-quality issue.
+
+- **Sample size guidance (Figure 7)** — paper estimates RMSE between
+  smaller-subset MOS and full-sample MOS. Drops below 2 RMSE points at
+  ~50 anchor opinions + ~5 TSBPC opinions/pair. Our v15r corpus has
+  ~1,800 cells/source × 981 sources = 1.77M total, well above the
+  signal-saturation point.
+
+- **Mobile vs desktop** — paper screens out mobile participants because
+  viewing conditions are uncontrolled. We don't have human evaluators
+  but **viewing-condition features** (pixel angular size, dpi assumption)
+  remain unmodeled in zensim and were called out in PR #24 follow-up
+  list (zensim issue #25 — crowdsourced human eval web app).
+
+## Concrete v_next plan adjustments
+
+1. **Train target = `score_ssim2`.** SSIM2 IS the canonical CID22 MCOS
+   scale (Table 5), the best held-out metric on the canonical IQA
+   benchmark, and what `score_zensim` already systematically biases
+   away from in our 2.37M-row corpus.
+
+2. **Loss = RankNet within (image, codec) groups.** Pairwise correlation
+   is +0.04..+0.05 better than absolute (Table 6 vs 3 across every
+   metric). `train_v_next_mlp.py --loss mse_rank` is already wired.
+
+3. **Add monotonicity penalty.** Within each (image, codec, knobs)
+   curve, penalize `max(0, score(q_i) - score(q_{i+1}))` — directly
+   addresses the 71,115 monotonicity violations we found in v15r/v15rc.
+   Paper's "forced monotonicity" precedent.
+
+4. **Hold out the 49 CID22 references for evaluation, NOT training.**
+   Already enforced via `make_split` source-disjoint splitter +
+   `CID22_VALIDATION_41` blocklist in synthetic generator. Keep this
+   strict — when V0_4 retrains, evaluate on those 4,292 pairs and
+   report SROCC against MCOS, not against ssim2.
+
+5. **Score-mapping target = piecewise-linear-21 fit to MCOS scale.**
+   Means: visually lossless → 90, high → 65, medium → 50. PR #24
+   `v04_calibrate_mapping.rs` does exactly this (using ssim2 as a proxy
+   for MCOS). After PR #24 lands, refit on the 2.37M-row unified parquet
+   to remove the +7..+11 systematic bias.
+
+6. **Multi-scale handoff TODO §4.3 is REINFORCED** by paper's 6-scale
+   choice. Run multi-scale subset sweep (8 sizes × 100 cluster-centroid
+   sources × 5 q × default knobs) and verify zensim score across scales
+   for the same `(source, distortion-type, target)` is within ±2
+   points; if not, V0_5 design needs a 5th or 6th scale.
+
+7. **Reproducibility:** download the 30-page paper to durable storage,
+   mirror to R2 next to the unified data so vast.ai workers can pull
+   both in one step. Done — `/mnt/v/zen/zensim-training/2026-05-07/papers/CID22_wg1m99012.pdf`.

--- a/docs/PR_24_REVIEW_2026-05-07.md
+++ b/docs/PR_24_REVIEW_2026-05-07.md
@@ -1,0 +1,206 @@
+# PR #24 review — what to merge, what to supplant
+
+**Date:** 2026-05-07
+**Branch reviewed:** `origin/v04-mlp` @ `d5e24b4` (9 commits over `main`)
+**PR title:** feat(zensim): V0_4 MLP scoring via zenpredict (+0.025 CID22 SROCC over V0_2)
+
+This is a **scoped review** that decides which of PR #24's 7,388 added lines
+should land vs which are now better produced by the
+`zenanalyze/zentrain` (Python) + `zenmetrics` (Rust sweep) toolchain that
+landed after this PR was opened.
+
+## Top-line recommendation
+
+| Bucket | Files | Action |
+|---|---|---|
+| Runtime + dispatch | `zensim/src/{mlp,profile,metric,lib}.rs`, `zensim/Cargo.toml`, `zensim/tests/v04_mlp.rs` | **MERGE** |
+| Score-mapping calibration tooling (piecewise-21 + power-law) | `zensim-bench/examples/v04_calibrate_mapping.rs`, `benchmarks/v04_calibrate_mapping_2026-05-01.md` | **MERGE** |
+| Profile compatibility report | `zensim-bench/examples/profile_compat_report.rs`, related .md/.meta | **MERGE** |
+| KonJND-1k anchor integration | `dataset_metric_baseline.rs`, `baseline_metrics_with_konjnd_2026-05-01.md` | **MERGE** |
+| LINEAR_WEIGHTS_PREVIEW aliases + active-channels bench | `zensim-bench/examples/v02_active_channels.rs`, `profile.rs` aliases | **MERGE** |
+| In-tree RankNet trainer | `zensim-validate/src/mlp_train.rs` (885 lines), `mlp_importance.rs` (416 lines), `main.rs` deltas | **DEFER — supplant by `zenanalyze/zentrain`** |
+| Bake artifact V0_4 placeholder swap | trained weight blob (not in PR) | **REPLACE — retrain on v15r/v15rc data** |
+| 3-norm butteraugli generator | `zensim-bench/examples/gen_butteraugli_3norm.rs` | **MERGE** (small, reusable) |
+| Calibration scripts (.py) | `benchmarks/v04_to_ssim2_*.py`, `v04_ssim2_*.py` | **MERGE** as historical record; scripts will be re-run on the new data |
+| Doc/CLAUDE.md/CHANGELOG conflicts | `CLAUDE.md`, `CHANGELOG.md`, `docs/NEXT_TIER_DATA_PLAN.md` | **TAKE MAIN** (those docs were updated post-fork — diff is one-direction) |
+
+The runtime side of PR #24 is the load-bearing piece; everything that
+trained or scored a *specific* model is now better produced through the
+mature `zenanalyze/zentrain` → `zenpredict` → `zensim` pipeline that
+exists today.
+
+## Per-commit detail
+
+### 1. `38a5d30` — V0_4 profile + dispatch scaffolding
+
+Files: `zensim/src/{mlp/{bake,error,inference,model,scorer,tests,mod},profile,metric,lib}.rs`, `zensim/tests/v04_mlp.rs`
+
+**Status:** superseded by commit `3ffc74a` in the same PR. `38a5d30` vendored
+the MLP runtime in-tree (`zensim/src/mlp/{inference,model,scorer,bake,error}.rs`,
+1,802 lines). Then `3ffc74a` ripped that out (`zensim/src/mlp/*.rs` deleted)
+and replaced with a thin re-export over `zenpredict`.
+
+**Action:** when cherry-picking, take `3ffc74a`'s end-state of `zensim/src/mlp/mod.rs`
+(~50-line re-export), not `38a5d30`'s vendored files. Profile + metric.rs
+deltas are correct in either commit.
+
+### 2. `3ffc74a` — Adopt zenpredict ZNPR v2 (the right runtime)
+
+Files: `zensim/src/mlp/mod.rs` (re-export), `Cargo.toml` (zenpredict dep),
+`zensim/src/profile.rs`, `zensim/src/metric.rs` (MLP dispatch), plus
+**deletions** of the in-tree MLP files vendored in `38a5d30`.
+
+This is **the canonical runtime form** for V0_4 (and beyond). Required.
+
+**Action:** MERGE. zenpredict is now MIT/Apache, no license drift. The
+ZNPR v2 format is the same one zentrain bakes through.
+
+### 3. `533e732` — LINEAR_WEIGHTS_PREVIEW aliases + baseline-metric bench
+
+Files: `zensim/src/profile.rs` aliases, `zensim-bench/examples/v02_active_channels.rs`,
+`zensim-bench/examples/dataset_metric_baseline.rs` (initial 421 lines).
+
+**Action:** MERGE. The aliases are safe (additive). The baseline-metric
+bench is reusable — `zentrain` doesn't replace baseline SROCC reporting.
+
+### 4. `8dbec15` — V0_2 vs V0_4 profile compatibility report
+
+Files: `zensim-bench/examples/profile_compat_report.rs` (848 lines),
+benchmarks .md/.meta.
+
+**Action:** MERGE. Generic compat-report harness is independent of the
+trained weights — runs against whichever V0_4 we end up shipping.
+
+### 5. `3494f93` — V0_4 score-mapping calibration
+
+Files: `zensim-bench/examples/v04_calibrate_mapping.rs` (824 lines),
+`benchmarks/v04_calibrate_mapping_2026-05-01.md`.
+
+**Action:** MERGE. The calibration harness implements piecewise-linear-21
+score mapping (42 f64 storage). This is **directly useful for v_next** —
+analyze_score_quality.py shows zensim is systematically +7..+11 points
+above ssim2 on zenjpeg, which is exactly a score-mapping miscalibration.
+We'll re-run this harness on v15r/v15rc data to refit `score_mapping_a/b`.
+
+### 6. `361bdfc` — KonJND-1k integration
+
+Files: bench examples, baseline metrics doc.
+
+**Action:** MERGE. Visually-lossless anchor is independent of model choice.
+
+### 7. `616fd7d` — Butteraugli 3-norm trainer target
+
+Files: `zensim-bench/examples/gen_butteraugli_3norm.rs`, `zensim-validate/src/main.rs`
+(9 added lines wiring 3-norm target into the in-tree trainer).
+
+**Partial keep:** the Rust `gen_butteraugli_3norm.rs` example is a small,
+reusable helper (175 lines). MERGE it.
+
+The 9-line `main.rs` add wires it into the in-tree RankNet trainer
+(`mlp_train.rs`). That trainer is being supplanted (see #8) — but the
+`main.rs` change is small enough that it's easier to merge alongside
+than ablate, and the dead code path can be cleaned up when we delete
+the in-tree trainer in a separate PR.
+
+### 8. `6fb8472` — Retrained V0_4 MLP on butteraugli 3-norm
+
+Files: `benchmarks/v04_3norm_baseline_2026-05-01.md`,
+`benchmarks/v04_3norm_compat_2026-05-01.md`. **No code changes.**
+
+**Action:** MERGE the .md files as historical record. The bake artifact
+itself is at `/mnt/v/output/zensim/synthetic-v2/runs/v04_mlp_v5znpr2_*.bin`
+and was trained on the old synthetic-v2 corpus (218k pairs). It will
+be **superseded** by a retrain on v15r+v15rc unified data (2.37M
+pairs, 1024 px corpus, 5 content classes) — but the bake artifact
+isn't versioned in this PR, so there's nothing to discard.
+
+### 9. `d5e24b4` — SSIM2-target retrain
+
+Files: `benchmarks/v04_to_ssim2_*.{py,md,png}`,
+`benchmarks/v04_ssim2_*.{md,png}`,
+`zensim-bench/examples/dataset_metric_baseline.rs` (+36 lines).
+
+**Action:** MERGE. The Python calibration scripts (rat_fit, poly_shift,
+calibrate, overlap, whisker) are reusable on the new data. The .md
+artifacts are historical record. No bake artifact to discard.
+
+## What's *not* coming over (and why)
+
+### `zensim-validate/src/mlp_train.rs` (885 lines)
+
+The in-tree RankNet trainer was the *original* training infrastructure for
+V0_4. Since this PR was opened, `zenanalyze/zentrain` has matured into
+a comprehensive Python pipeline:
+
+- `tools/train_hybrid.py` — HistGB teacher fit, parallel via joblib
+- `tools/train_distill.py` — student MLP distillation
+- `tools/feature_ablation.py` — four-tier feature pruning (correlation
+  → permutation → group → LOO)
+- `tools/bake_picker.py` — sklearn JSON → ZNPR v2 binary
+
+zentrain's training output is the same ZNPR v2 binary format that
+PR #24's runtime loads. There's no compelling reason to maintain a
+parallel Rust trainer in zensim-validate.
+
+**Decision:** when the PR's runtime pieces land, file a follow-up to
+**delete** `zensim-validate/src/mlp_train.rs`,
+`zensim-validate/src/bin/mlp_importance.rs`, and the trainer-wiring
+in `zensim-validate/src/main.rs`. v_next training goes through
+`zenanalyze/zentrain`, fed by the unified parquet at
+`/mnt/v/zen/zensim-training/2026-05-07/unified/`.
+
+### V0_4 bake artifact
+
+The `v04_mlp_v5znpr2_20260430T044620.bin` bake was trained on
+synthetic-v2 (218k pairs, KADIK + TID + CID22 + small synthetic
+training). The **2,374,666-row** unified parquet that landed today is
+~10× larger, content-class stratified, and has 4 ground-truth metric
+columns per cell (zensim, ssim2, butteraugli_max, butteraugli_pnorm3).
+
+**Decision:** retrain V0_4 (or V0_5 / V_NEXT) on the new corpus via
+zentrain. The PR #24 bake is a *placeholder* — its weights bit-reproduce
+V0_2 (per the PR body). Replacing the placeholder is a single
+`include_bytes!` flip + a `score_mapping_a/b` refit, exactly the
+flow the calibration tooling in this PR enables.
+
+### `docs/NEXT_TIER_DATA_PLAN.md` deletion
+
+PR #24 shows `docs/NEXT_TIER_DATA_PLAN.md` as `-535` lines. That doc
+was *added* on `main` in commit `274ebcb` *after* this PR branched.
+The 3-way merge will keep main's version. No action needed.
+
+## Merge plan
+
+1. Cherry-pick the runtime/scaffolding/calibration commits in order:
+   `38a5d30 → 3ffc74a → 533e732 → 8dbec15 → 3494f93 → 361bdfc → 616fd7d → 6fb8472 → d5e24b4`,
+   resolving conflicts in `Cargo.toml`, `zensim/src/profile.rs`,
+   `zensim/src/metric.rs`. Take main's CLAUDE.md / CHANGELOG.md /
+   `docs/NEXT_TIER_DATA_PLAN.md`.
+
+2. Run `cargo test --workspace` and `cargo clippy --workspace --all-targets`
+   green before push.
+
+3. Open a follow-up PR (call it "PR #24 followups: trainer cleanup")
+   that **removes**:
+   - `zensim-validate/src/mlp_train.rs`
+   - `zensim-validate/src/bin/mlp_importance.rs`
+   - the `mlp-train` subcommand wiring in `zensim-validate/src/main.rs`
+   …and points at zentrain in CLAUDE.md.
+
+4. Open a v_next training PR that:
+   - Bakes a new V0_4 (or V0_5) MLP on the unified parquet via zentrain
+   - Refits `score_mapping_a/b` via `v04_calibrate_mapping.rs` on the
+     new data — analyze_score_quality.py shows the +7..+11 systematic
+     bias is exactly what calibration is for
+   - Drops the trained weights into `zensim/src/profile.rs` via
+     `include_bytes!`, flips `PreviewV0_4` to use them, validates on
+     CID22/KADIK/TID held-out per `NEXT_TIER_DATA_PLAN.md §6`.
+
+## Coordination with `docs/V_NEXT_HANDOFF_2026-05-07.md`
+
+This review supersedes the handoff doc's TODO §4.6 "Multi-task
+supervision" — that lives now in zentrain's training pipeline rather
+than in the in-tree trainer that's being deprecated. Other handoff
+TODOs (§4.2 cross-codec sweeps, §4.3 multi-scale, §4.4 adversarial
+mining, §4.7 size normalization) remain valid and are unblocked once
+PR #24's runtime lands.

--- a/scripts/v_next/analyze_score_quality.py
+++ b/scripts/v_next/analyze_score_quality.py
@@ -39,16 +39,22 @@ import pyarrow.parquet as pq
 DEFAULT_DIR = Path("/mnt/v/zen/zensim-training/2026-05-07/unified")
 
 
-def load_unified(input_dir: Path) -> pd.DataFrame:
+def load_unified(input_dir: Path, sweeps: list[str] | None = None) -> pd.DataFrame:
     parqs = sorted(input_dir.glob("unified_*.parquet"))
+    if sweeps:
+        parqs = [p for p in parqs
+                 if any(p.name.startswith(f"unified_{s}_") for s in sweeps)]
     if not parqs:
-        raise SystemExit(f"no unified parquets in {input_dir}")
+        raise SystemExit(f"no unified parquets in {input_dir} matching {sweeps}")
     print(f"Loading {len(parqs)} parquet shards ...")
-    keep_cols = None
-    frames = []
+    keep_cols: list[str] | None = None
+    frames: list[pd.DataFrame] = []
     for p in parqs:
-        cols_in_file = pq.ParquetFile(p).schema.names
-        # Skip raw 300-feat columns for analysis (massive, not needed here)
+        try:
+            cols_in_file = pq.ParquetFile(p).schema.names
+        except Exception as e:
+            print(f"  SKIP {p.name}: {e}")
+            continue
         if keep_cols is None:
             keep_cols = [c for c in cols_in_file if not c.startswith("feat_")]
         keep_now = [c for c in keep_cols if c in cols_in_file]
@@ -56,6 +62,8 @@ def load_unified(input_dir: Path) -> pd.DataFrame:
         df["__shard"] = p.name
         frames.append(df)
         print(f"  {p.name}: {len(df):,} rows")
+    if not frames:
+        raise SystemExit("no readable parquets")
     full = pd.concat(frames, ignore_index=True)
     print(f"Total: {len(full):,} rows × {full.shape[1]} cols")
     return full
@@ -112,30 +120,48 @@ def bumpiness_per_curve(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def disagreement_residual(df: pd.DataFrame) -> pd.DataFrame:
-    """delta = zensim_score - 100*(1 - clip(butteraugli_max / 6.0, 0, 1))
-    Larger |delta| means stronger disagreement.
+    """delta_ba = zensim_score - 100*(1 - clip(butteraugli_max/6, 0, 1))
+       delta_ssim2 = zensim_score - score_ssim2
+
+    Returns whichever residuals are computable from the available columns.
+    Some sweep×codec combos lack one or both reference metrics.
     """
-    work = df.dropna(subset=["score_zensim", "score_butteraugli_max"]).copy()
-    ba_proxy = 100.0 * (1.0 - np.clip(work["score_butteraugli_max"] / 6.0, 0.0, 1.0))
-    work["delta_ba"] = work["score_zensim"] - ba_proxy
-    if "score_ssim2" in work.columns:
-        s2 = work["score_ssim2"].fillna(np.nan)
-        work["delta_ssim2"] = work["score_zensim"] - s2
-    return work[["sweep_id", "image_basename", "codec", "q", "knob_tuple_json",
-                 "score_zensim", "score_ssim2", "score_butteraugli_max",
-                 "delta_ba"] + (["delta_ssim2"] if "score_ssim2" in work.columns else [])]
+    needed = ["score_zensim"]
+    has_ba = "score_butteraugli_max" in df.columns
+    has_s2 = "score_ssim2" in df.columns
+    if not has_ba and not has_s2:
+        return pd.DataFrame()
+    drop_subset = needed + (["score_butteraugli_max"] if has_ba else []) \
+                          + (["score_ssim2"] if has_s2 else [])
+    work = df.dropna(subset=drop_subset).copy()
+    if has_ba:
+        ba_proxy = 100.0 * (1.0 - np.clip(work["score_butteraugli_max"] / 6.0,
+                                           0.0, 1.0))
+        work["delta_ba"] = work["score_zensim"] - ba_proxy
+    if has_s2:
+        work["delta_ssim2"] = work["score_zensim"] - work["score_ssim2"]
+    cols = ["sweep_id", "image_basename", "codec", "q", "knob_tuple_json",
+            "score_zensim"]
+    if has_ba:
+        cols += ["score_butteraugli_max", "delta_ba"]
+    if has_s2:
+        cols += ["score_ssim2", "delta_ssim2"]
+    return work[cols]
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--input-dir", default=str(DEFAULT_DIR))
+    ap.add_argument("--sweeps", default=None,
+                    help="Comma-separated sweep ids to include (default: all readable)")
     ap.add_argument("--top-k", type=int, default=5000)
     ap.add_argument("--mono-eps", type=float, default=0.5,
                     help="Min downward step (in zensim points) to flag")
     args = ap.parse_args()
 
     in_dir = Path(args.input_dir)
-    df = load_unified(in_dir)
+    sweeps = args.sweeps.split(",") if args.sweeps else None
+    df = load_unified(in_dir, sweeps=sweeps)
 
     print("\n# 1. Monotonicity violations")
     mv = find_monotonicity_violations(df, eps=args.mono_eps)
@@ -163,26 +189,31 @@ def main() -> int:
         print(f"  {len(bp):,} curves → {out.name}")
         print(agg.to_string())
 
-    print("\n# 3. zensim ↔ butteraugli disagreement")
+    print("\n# 3. zensim ↔ reference-metric disagreement")
     da = disagreement_residual(df)
-    if not da.empty:
-        # Top 5k high+low residuals as adversarial seeds
-        top_high = da.nlargest(args.top_k, "delta_ba")
-        top_low = da.nsmallest(args.top_k, "delta_ba")
+    if da.empty:
+        print("  no reference-metric columns available; skipping")
+    else:
+        sort_col = "delta_ba" if "delta_ba" in da.columns else "delta_ssim2"
+        top_high = da.nlargest(args.top_k, sort_col)
+        top_low = da.nsmallest(args.top_k, sort_col)
         adv = pd.concat([top_high, top_low], ignore_index=True)
         out = in_dir / "adversarial_pairs_top_disagree.parquet"
         adv.to_parquet(out, compression="zstd", compression_level=9)
-        print(f"  {len(adv):,} adversarial pairs → {out.name}")
-        print(f"  delta_ba: mean={da['delta_ba'].mean():+.2f} "
-              f"std={da['delta_ba'].std():.2f} "
-              f"p1={np.quantile(da['delta_ba'], 0.01):+.2f} "
-              f"p99={np.quantile(da['delta_ba'], 0.99):+.2f}")
-        per_codec = da.groupby(["sweep_id", "codec"])["delta_ba"].agg(
-            n="size", mean="mean", std="std",
-            p1=lambda s: float(np.quantile(s, 0.01)),
-            p99=lambda s: float(np.quantile(s, 0.99)),
-        )
-        print(per_codec.to_string())
+        print(f"  {len(adv):,} adversarial pairs (sorted by {sort_col}) → {out.name}")
+        for col in ("delta_ba", "delta_ssim2"):
+            if col not in da.columns:
+                continue
+            print(f"  {col}: mean={da[col].mean():+.2f} "
+                  f"std={da[col].std():.2f} "
+                  f"p1={np.quantile(da[col], 0.01):+.2f} "
+                  f"p99={np.quantile(da[col], 0.99):+.2f}")
+            per_codec = da.groupby(["sweep_id", "codec"])[col].agg(
+                n="size", mean="mean", std="std",
+                p1=lambda s: float(np.quantile(s, 0.01)),
+                p99=lambda s: float(np.quantile(s, 0.99)),
+            )
+            print(per_codec.to_string())
 
     return 0
 

--- a/scripts/v_next/analyze_score_quality.py
+++ b/scripts/v_next/analyze_score_quality.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Score-quality diagnostics on the unified v_next parquet(s).
+
+Surfaces three categories of zensim quality issue, all detected from data the
+unified parquet already has (no model retrain needed):
+
+1. Monotonicity violations
+   - Sort by q within each (image, codec, knob_tuple_json) group.
+   - Count adjacent (q_i < q_{i+1}) pairs where score went DOWN by > eps.
+   - Report worst offenders + per-codec aggregates.
+
+2. Bumpiness (curve roughness)
+   - For each monotone-enough curve, fit a smooth reference (rolling median)
+     and compute mean absolute residual of zensim_score from it.
+   - Compare to reference metrics (ssim2, butteraugli) on the same curve to
+     see if "bumpiness" is a property of the input pair (e.g. codec mode
+     switch) vs zensim specifically.
+
+3. Disagreement with reference metrics
+   - For every cell, compute residual = zensim - 100*(1 - clamp(butteraugli_max/6, 0, 1))
+     and the simpler delta vs ssim2.
+   - Emit top-K positive/negative pairs as adversarial-mining seeds (TODO 4.4).
+
+Outputs:
+  /mnt/v/zen/zensim-training/2026-05-07/unified/score_quality_summary.tsv
+  /mnt/v/zen/zensim-training/2026-05-07/unified/monotonicity_violations.tsv
+  /mnt/v/zen/zensim-training/2026-05-07/unified/adversarial_pairs_top_disagree.parquet
+
+Usage:
+  python3 analyze_score_quality.py [--input-dir DIR] [--top-k 5000]
+"""
+import argparse
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+DEFAULT_DIR = Path("/mnt/v/zen/zensim-training/2026-05-07/unified")
+
+
+def load_unified(input_dir: Path) -> pd.DataFrame:
+    parqs = sorted(input_dir.glob("unified_*.parquet"))
+    if not parqs:
+        raise SystemExit(f"no unified parquets in {input_dir}")
+    print(f"Loading {len(parqs)} parquet shards ...")
+    keep_cols = None
+    frames = []
+    for p in parqs:
+        cols_in_file = pq.ParquetFile(p).schema.names
+        # Skip raw 300-feat columns for analysis (massive, not needed here)
+        if keep_cols is None:
+            keep_cols = [c for c in cols_in_file if not c.startswith("feat_")]
+        keep_now = [c for c in keep_cols if c in cols_in_file]
+        df = pq.read_table(p, columns=keep_now).to_pandas()
+        df["__shard"] = p.name
+        frames.append(df)
+        print(f"  {p.name}: {len(df):,} rows")
+    full = pd.concat(frames, ignore_index=True)
+    print(f"Total: {len(full):,} rows × {full.shape[1]} cols")
+    return full
+
+
+def find_monotonicity_violations(df: pd.DataFrame, eps: float = 0.5) -> pd.DataFrame:
+    """For each (image, codec, knob_tuple_json) group, sort by q and find
+    adjacent q-pairs where score_zensim went DOWN by > eps."""
+    keys = ["sweep_id", "image_basename", "codec", "knob_tuple_json"]
+    needed = keys + ["q", "score_zensim", "score_ssim2", "score_butteraugli_max"]
+    work = df[[c for c in needed if c in df.columns]].dropna(
+        subset=["score_zensim", "q"]
+    ).copy()
+    work = work.sort_values(keys + ["q"])
+    grouped = work.groupby(keys, sort=False)
+    rows = []
+    for key_vals, g in grouped:
+        if len(g) < 2:
+            continue
+        zs = g["score_zensim"].to_numpy()
+        qs = g["q"].to_numpy()
+        diffs = np.diff(zs)
+        for i, d in enumerate(diffs):
+            if d < -eps:
+                rec = dict(zip(keys, key_vals))
+                rec.update({
+                    "q_lo": qs[i], "q_hi": qs[i+1],
+                    "zensim_lo": zs[i], "zensim_hi": zs[i+1],
+                    "drop": d,
+                })
+                rows.append(rec)
+    return pd.DataFrame(rows)
+
+
+def bumpiness_per_curve(df: pd.DataFrame) -> pd.DataFrame:
+    """For each (image, codec, knobs) curve, compute residual of zensim_score
+    from a rolling-median smooth as a roughness proxy."""
+    keys = ["sweep_id", "image_basename", "codec", "knob_tuple_json"]
+    work = df.dropna(subset=["score_zensim", "q"]).sort_values(keys + ["q"])
+    rows = []
+    for key_vals, g in work.groupby(keys, sort=False):
+        if len(g) < 5:
+            continue
+        z = g["score_zensim"].to_numpy()
+        smooth = pd.Series(z).rolling(3, center=True, min_periods=1).median().to_numpy()
+        bumpiness = float(np.mean(np.abs(z - smooth)))
+        rec = dict(zip(keys, key_vals))
+        rec["n_q"] = len(g)
+        rec["bumpiness_mae"] = bumpiness
+        rec["zensim_min"] = float(z.min())
+        rec["zensim_max"] = float(z.max())
+        rows.append(rec)
+    return pd.DataFrame(rows)
+
+
+def disagreement_residual(df: pd.DataFrame) -> pd.DataFrame:
+    """delta = zensim_score - 100*(1 - clip(butteraugli_max / 6.0, 0, 1))
+    Larger |delta| means stronger disagreement.
+    """
+    work = df.dropna(subset=["score_zensim", "score_butteraugli_max"]).copy()
+    ba_proxy = 100.0 * (1.0 - np.clip(work["score_butteraugli_max"] / 6.0, 0.0, 1.0))
+    work["delta_ba"] = work["score_zensim"] - ba_proxy
+    if "score_ssim2" in work.columns:
+        s2 = work["score_ssim2"].fillna(np.nan)
+        work["delta_ssim2"] = work["score_zensim"] - s2
+    return work[["sweep_id", "image_basename", "codec", "q", "knob_tuple_json",
+                 "score_zensim", "score_ssim2", "score_butteraugli_max",
+                 "delta_ba"] + (["delta_ssim2"] if "score_ssim2" in work.columns else [])]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input-dir", default=str(DEFAULT_DIR))
+    ap.add_argument("--top-k", type=int, default=5000)
+    ap.add_argument("--mono-eps", type=float, default=0.5,
+                    help="Min downward step (in zensim points) to flag")
+    args = ap.parse_args()
+
+    in_dir = Path(args.input_dir)
+    df = load_unified(in_dir)
+
+    print("\n# 1. Monotonicity violations")
+    mv = find_monotonicity_violations(df, eps=args.mono_eps)
+    if mv.empty:
+        print("  no violations found at eps =", args.mono_eps)
+    else:
+        out = in_dir / "monotonicity_violations.tsv"
+        mv.sort_values("drop").to_csv(out, sep="\t", index=False)
+        agg = mv.groupby(["sweep_id", "codec"])["drop"].agg(
+            count="size", mean_drop="mean", worst_drop="min"
+        )
+        print(f"  {len(mv):,} violations (eps={args.mono_eps}) → {out.name}")
+        print(agg.to_string())
+
+    print("\n# 2. Bumpiness per curve")
+    bp = bumpiness_per_curve(df)
+    if not bp.empty:
+        out = in_dir / "bumpiness_per_curve.tsv"
+        bp.sort_values("bumpiness_mae", ascending=False).to_csv(out, sep="\t",
+                                                                  index=False)
+        agg = bp.groupby(["sweep_id", "codec"])["bumpiness_mae"].agg(
+            n="size", mean="mean", p95=lambda s: float(np.quantile(s, 0.95)),
+            max="max"
+        )
+        print(f"  {len(bp):,} curves → {out.name}")
+        print(agg.to_string())
+
+    print("\n# 3. zensim ↔ butteraugli disagreement")
+    da = disagreement_residual(df)
+    if not da.empty:
+        # Top 5k high+low residuals as adversarial seeds
+        top_high = da.nlargest(args.top_k, "delta_ba")
+        top_low = da.nsmallest(args.top_k, "delta_ba")
+        adv = pd.concat([top_high, top_low], ignore_index=True)
+        out = in_dir / "adversarial_pairs_top_disagree.parquet"
+        adv.to_parquet(out, compression="zstd", compression_level=9)
+        print(f"  {len(adv):,} adversarial pairs → {out.name}")
+        print(f"  delta_ba: mean={da['delta_ba'].mean():+.2f} "
+              f"std={da['delta_ba'].std():.2f} "
+              f"p1={np.quantile(da['delta_ba'], 0.01):+.2f} "
+              f"p99={np.quantile(da['delta_ba'], 0.99):+.2f}")
+        per_codec = da.groupby(["sweep_id", "codec"])["delta_ba"].agg(
+            n="size", mean="mean", std="std",
+            p1=lambda s: float(np.quantile(s, 0.01)),
+            p99=lambda s: float(np.quantile(s, 0.99)),
+        )
+        print(per_codec.to_string())
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/v_next/build_unified_parquet.py
+++ b/scripts/v_next/build_unified_parquet.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Build unified training parquet from v15r/v15rc/v13/v14/v12 sweeps.
+
+For each sweep, joins the per-source `.features.parquet` (300 zensim features
++ knob keys) with its matching `.tsv` (encoded_bytes, encode_ms, decode_ms,
+score_{zensim,ssim2,butteraugli_max,butteraugli_pnorm3}) on the composite
+key (basename(image_path), codec, q, knob_tuple_json).
+
+Adds:
+- `sweep_id`         — e.g. "v15r", "v15rc", "v12"
+- `image_basename`   — strips /workspace/sweep/stage-*/ prefix from image_path
+- `content_class`    — joined from features_v15r_combined.tsv (v15r/v15rc only)
+- `corpus_features_*`— 33 named zenanalyze features per source (v15r/v15rc only)
+
+Output: /mnt/v/zen/zensim-training/2026-05-07/unified/training_unified.parquet
+
+Usage:
+    python3 build_unified_parquet.py [--sweeps v15r,v15rc,v13,v14,v12]
+                                     [--limit-files N]   # debug: only N TSVs per sweep
+                                     [--out PATH]
+"""
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+ROOT = Path("/mnt/v/zen/zensim-training/2026-05-07")
+DEFAULT_OUT = ROOT / "unified" / "training_unified.parquet"
+CORPUS_FEATURES_TSV = ROOT / "v15r-prep" / "features_v15r_combined.tsv"
+
+# Per-sweep TSV+parquet locations, by (sweep_id, codec) → directory
+SWEEP_LAYOUT = {
+    ("v15r",  "zenjpeg"): (
+        ROOT / "v15r-prep" / "data" / "zenjpeg",   # TSVs (synced earlier)
+        ROOT / "v15r" / "zenjpeg",                  # feature parquets
+    ),
+    ("v15rc", "zenjpeg"): (
+        ROOT / "v15rc" / "zenjpeg",                # both TSVs + parquets co-located
+        ROOT / "v15rc" / "zenjpeg",
+    ),
+    ("v13",   "zenjpeg"): (
+        ROOT / "v13" / "zenjpeg",
+        ROOT / "v13" / "zenjpeg",
+    ),
+    ("v14",   "zenpng"): (
+        ROOT / "v14" / "zenpng",
+        ROOT / "v14" / "zenpng",
+    ),
+    ("v12",   "zenavif"): (
+        ROOT / "v12" / "zenavif",
+        ROOT / "v12" / "zenavif",
+    ),
+    ("v12",   "zenjxl"): (
+        ROOT / "v12" / "zenjxl",
+        ROOT / "v12" / "zenjxl",
+    ),
+    ("v12",   "zenwebp"): (
+        ROOT / "v12" / "zenwebp",
+        ROOT / "v12" / "zenwebp",
+    ),
+}
+
+WORKSPACE_PREFIX_RE = re.compile(r"^/workspace/sweep/stage-[^/]+/")
+
+
+def normalize_basename(image_path: str) -> str:
+    """Strip /workspace/sweep/stage-*/ prefix from image path. Returns basename."""
+    p = WORKSPACE_PREFIX_RE.sub("", image_path)
+    return os.path.basename(p)
+
+
+def load_corpus_features() -> pd.DataFrame:
+    """Load 33-feature zenanalyze TSV and build a basename→features lookup."""
+    if not CORPUS_FEATURES_TSV.exists():
+        print(f"WARN: corpus features TSV missing: {CORPUS_FEATURES_TSV}")
+        return pd.DataFrame()
+    df = pd.read_csv(CORPUS_FEATURES_TSV, sep="\t")
+    df["image_basename"] = df["image_path"].map(normalize_basename)
+    keep = ["image_basename", "content_class", "size_class", "width", "height"]
+    feat_cols = [c for c in df.columns if c.startswith("feat_")]
+    keep += feat_cols
+    out = df[keep].drop_duplicates(subset=["image_basename"]).rename(
+        columns={c: f"corpus_{c}" for c in feat_cols}
+    )
+    print(f"  corpus features: {len(out)} unique basenames, {len(feat_cols)} feat_* cols")
+    return out
+
+
+NUMERIC_TSV_COLS = (
+    "encoded_bytes", "encode_ms", "decode_ms",
+    "score_zensim", "score_ssim2",
+    "score_butteraugli_max", "score_butteraugli_pnorm3",
+    "score_ssim2_gpu",
+    "score_butteraugli_max_gpu", "score_butteraugli_pnorm3_gpu",
+)
+
+
+CANONICAL_METRIC_COLS = (
+    "score_zensim", "score_ssim2",
+    "score_butteraugli_max", "score_butteraugli_pnorm3",
+)
+
+
+def coalesce_gpu_metrics(df: pd.DataFrame) -> pd.DataFrame:
+    """Some workers emitted `score_ssim2_gpu` / `score_butteraugli_*_gpu` while
+    others emitted CPU column names. Coalesce into a single canonical name and
+    record which path the row used in `metric_runtime` ("gpu" | "cpu" | "mixed").
+    """
+    runtime = pd.Series(["cpu"] * len(df), index=df.index)
+    for canonical in CANONICAL_METRIC_COLS:
+        gpu_col = canonical + "_gpu"
+        if gpu_col in df.columns and canonical in df.columns:
+            # Prefer non-null value from either column.
+            df[canonical] = df[canonical].where(df[canonical].notna(), df[gpu_col])
+            runtime = runtime.where(df[gpu_col].isna(), "gpu")
+            df = df.drop(columns=[gpu_col])
+        elif gpu_col in df.columns:
+            df = df.rename(columns={gpu_col: canonical})
+            runtime = pd.Series(["gpu"] * len(df), index=df.index)
+    df["metric_runtime"] = runtime
+    return df
+
+
+def join_pair(tsv_path: Path, parquet_path: Path) -> pd.DataFrame | None:
+    """Join one (.tsv, .features.parquet) pair on the composite key.
+
+    Forces numeric metric columns to float64 (empty strings on encode/decode
+    failures become NaN) and coalesces `score_*_gpu` aliases so streaming
+    concat across files keeps a stable pyarrow schema.
+    """
+    if not tsv_path.exists() or not parquet_path.exists():
+        return None
+    tsv = pd.read_csv(tsv_path, sep="\t", low_memory=False)
+    for col in NUMERIC_TSV_COLS:
+        if col in tsv.columns:
+            tsv[col] = pd.to_numeric(tsv[col], errors="coerce")
+    feat = pq.read_table(parquet_path).to_pandas()
+
+    key = ["image_path", "codec", "q", "knob_tuple_json"]
+    merged = tsv.merge(feat, on=key, how="inner", suffixes=("", "_feat"))
+    if "zensim_score" in merged.columns and "score_zensim" in merged.columns:
+        merged = merged.drop(columns=["zensim_score"])
+    merged = coalesce_gpu_metrics(merged)
+    return merged
+
+
+def build_sweep(sweep_id: str, codec: str, tsv_dir: Path, parq_dir: Path,
+                limit_files: int | None) -> pd.DataFrame:
+    rows = []
+    tsvs = sorted(tsv_dir.glob(f"{codec}-*.tsv"))
+    if limit_files:
+        tsvs = tsvs[:limit_files]
+    for tsv in tsvs:
+        # Find matching parquet — basenames identical except .tsv → .features.parquet
+        parq = parq_dir / tsv.name.replace(".tsv", ".features.parquet")
+        df = join_pair(tsv, parq)
+        if df is None or df.empty:
+            continue
+        df["sweep_id"] = sweep_id
+        rows.append(df)
+    if not rows:
+        return pd.DataFrame()
+    out = pd.concat(rows, ignore_index=True)
+    out["image_basename"] = out["image_path"].map(normalize_basename)
+    return out
+
+
+def write_sweep_parquet(out_path: Path, sweep_id: str, codec: str,
+                        tsv_dir: Path, parq_dir: Path,
+                        corpus_features: pd.DataFrame,
+                        limit_files: int | None) -> int:
+    """Streaming write: process one TSV/parquet pair at a time, append to a
+    ParquetWriter so we never hold the full sweep in RAM."""
+    tsvs = sorted(tsv_dir.glob(f"{codec}-*.tsv"))
+    if limit_files:
+        tsvs = tsvs[:limit_files]
+    if not tsvs:
+        return 0
+    writer: pq.ParquetWriter | None = None
+    total = 0
+    try:
+        for i, tsv in enumerate(tsvs):
+            parq = parq_dir / tsv.name.replace(".tsv", ".features.parquet")
+            df = join_pair(tsv, parq)
+            if df is None or df.empty:
+                continue
+            df["sweep_id"] = sweep_id
+            df["image_basename"] = df["image_path"].map(normalize_basename)
+            if not corpus_features.empty:
+                df = df.merge(corpus_features, on="image_basename", how="left")
+            tbl = pa.Table.from_pandas(df, preserve_index=False)
+            if writer is None:
+                writer = pq.ParquetWriter(out_path, tbl.schema,
+                                          compression="zstd",
+                                          compression_level=9)
+            writer.write_table(tbl)
+            total += len(df)
+            if (i + 1) % 50 == 0:
+                print(f"    [{sweep_id}/{codec}] {i+1}/{len(tsvs)} files, "
+                      f"{total:,} rows so far", flush=True)
+    finally:
+        if writer is not None:
+            writer.close()
+    return total
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sweeps", default="v15r,v15rc,v13,v14,v12",
+                    help="Comma-separated sweep ids to include")
+    ap.add_argument("--limit-files", type=int, default=None,
+                    help="Per-sweep cap on TSV/parquet pairs (debug)")
+    ap.add_argument("--out-dir", default=str(ROOT / "unified"),
+                    help="Per-sweep parquet output dir")
+    args = ap.parse_args()
+
+    wanted = set(args.sweeps.split(","))
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Building per-sweep unified parquets → {out_dir}")
+    print("Loading corpus features (zenanalyze 33-feature TSV) ...")
+    corpus_features = load_corpus_features()
+
+    summary: list[tuple[str, str, int, str]] = []
+    for (sweep_id, codec), (tsv_dir, parq_dir) in SWEEP_LAYOUT.items():
+        if sweep_id not in wanted:
+            continue
+        out_path = out_dir / f"unified_{sweep_id}_{codec}.parquet"
+        print(f"\n[{sweep_id}/{codec}] → {out_path.name}")
+        rows = write_sweep_parquet(out_path, sweep_id, codec, tsv_dir, parq_dir,
+                                    corpus_features, args.limit_files)
+        if rows == 0:
+            print(f"  -> 0 rows (no parquet written)")
+            if out_path.exists():
+                out_path.unlink()
+            continue
+        sz_mb = out_path.stat().st_size / 1024 / 1024
+        print(f"  -> {rows:,} rows, {sz_mb:.1f} MB")
+        summary.append((sweep_id, codec, rows, f"{sz_mb:.1f} MB"))
+
+    print("\nSummary:")
+    print(f"  {'sweep':<6} {'codec':<10} {'rows':>12} {'size':>12}")
+    for sid, c, r, s in summary:
+        print(f"  {sid:<6} {c:<10} {r:>12,} {s:>12}")
+    print(f"  {'TOTAL':<17} {sum(r for _,_,r,_ in summary):>12,}")
+    return 0 if summary else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/v_next/sync_unified_to_r2.sh
+++ b/scripts/v_next/sync_unified_to_r2.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Mirror /mnt/v/zen/zensim-training/2026-05-07/unified/ to R2 for reproducibility.
+#
+# Usage: bash scripts/v_next/sync_unified_to_r2.sh [--dry-run]
+#
+# Requires R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ACCOUNT_ID env vars
+# (already set in ~/.config/cloudflare/r2-env.sh, sourced by ~/.bashrc).
+set -euo pipefail
+
+LOCAL_DIR="/mnt/v/zen/zensim-training/2026-05-07/unified"
+R2_PREFIX="s3://zentrain/v_next-training/2026-05-07/unified"
+DRY=""
+[ "${1:-}" = "--dry-run" ] && DRY="--dryrun"
+
+if [ -z "${R2_ACCESS_KEY_ID:-}" ]; then
+  echo "ERROR: R2_ACCESS_KEY_ID not set; source ~/.config/cloudflare/r2-env.sh first." >&2
+  exit 1
+fi
+
+export AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
+ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+# Build a small manifest documenting the snapshot.
+MANIFEST="$LOCAL_DIR/_MANIFEST.json"
+GIT_COMMIT=$(cd "$(dirname "$0")/../.." && git rev-parse HEAD)
+GIT_BRANCH=$(cd "$(dirname "$0")/../.." && git rev-parse --abbrev-ref HEAD)
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+python3 - <<EOF > "$MANIFEST"
+import json, glob, os
+out = {
+    "generated_at": "$TS",
+    "git_commit": "$GIT_COMMIT",
+    "git_branch": "$GIT_BRANCH",
+    "parquets": [],
+}
+for p in sorted(glob.glob("$LOCAL_DIR/unified_*.parquet")):
+    name = os.path.basename(p)
+    sz = os.path.getsize(p)
+    try:
+        import pyarrow.parquet as pq
+        rows = pq.ParquetFile(p).metadata.num_rows
+    except Exception as e:
+        rows = -1
+    out["parquets"].append({"name": name, "rows": rows, "bytes": sz})
+print(json.dumps(out, indent=2))
+EOF
+
+echo "manifest:"
+cat "$MANIFEST"
+
+aws s3 sync $DRY \
+  --endpoint-url="$ENDPOINT" \
+  --exclude '*' \
+  --include 'unified_*.parquet' \
+  --include 'adversarial_pairs_*.parquet' \
+  --include 'monotonicity_violations.tsv' \
+  --include 'bumpiness_per_curve.tsv' \
+  --include 'score_quality_summary_*.log' \
+  --include '_MANIFEST.json' \
+  "$LOCAL_DIR/" "$R2_PREFIX/"
+
+echo "done — R2 prefix: $R2_PREFIX"

--- a/scripts/v_next/train_v_next_mlp.py
+++ b/scripts/v_next/train_v_next_mlp.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Train a 228 → H → 1 MLP perceptual scorer on the unified parquet.
+
+Targets (configurable via --target):
+- ssim2          (recommended; aligns zensim with the well-validated SSIMULACRA2)
+- butteraugli    (= score_butteraugli_max; classic, but lower CID22 ceiling)
+- butteraugli_p3 (= score_butteraugli_pnorm3; smoother, less max-driven)
+
+Validation: source-disjoint split on `image_basename`. 80/10/10.
+
+Architecture (default, matches V0_4 PR #24): 228 → 64 LeakyReLU → 1.
+
+Loss options (--loss):
+- mse       Direct regression to target (predict the SSIM2/BA score).
+- ranknet   Pairwise (sigmoid) ranking — same-image pairs at different
+            distortions; loss aligns with -SROCC at training time.
+- mse_rank  Sum: 1.0*MSE + 0.5*RankNet (recommended starting point).
+
+Usage:
+    python3 scripts/v_next/train_v_next_mlp.py \\
+        --input-dir /mnt/v/zen/zensim-training/2026-05-07/unified \\
+        --target ssim2 --loss mse_rank --hidden 64 --epochs 50 \\
+        --out-dir /mnt/v/zen/zensim-training/2026-05-07/runs
+
+Outputs:
+    runs/<TIMESTAMP>_<TAG>/
+        train.log
+        model.pt              (PyTorch state dict)
+        meta.json             (config + final metrics)
+        predictions_val.parquet (image, target, prediction, residual)
+
+The PyTorch model is trained on GPU when available; bake conversion to
+ZNPR v2 lives in a separate script (TBD: scripts/v_next/bake_to_znpr.py).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import time
+from dataclasses import dataclass, asdict
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+import torch
+from scipy import stats as sstats
+
+
+def load_parquets(input_dir: Path, sweeps: list[str]) -> pd.DataFrame:
+    parqs = []
+    for s in sweeps:
+        parqs.extend(sorted(input_dir.glob(f"unified_{s}_*.parquet")))
+    if not parqs:
+        raise SystemExit(f"no parquets matching sweeps={sweeps} in {input_dir}")
+    print(f"Loading {len(parqs)} parquets:")
+    keep_meta = ["sweep_id", "codec", "image_basename", "q", "knob_tuple_json",
+                 "score_zensim", "score_ssim2",
+                 "score_butteraugli_max", "score_butteraugli_pnorm3",
+                 "metric_runtime", "content_class"]
+    feat_cols = [f"feat_{i}" for i in range(228)]
+    frames = []
+    for p in parqs:
+        cols_avail = pq.ParquetFile(p).schema.names
+        cols = [c for c in keep_meta + feat_cols if c in cols_avail]
+        df = pq.read_table(p, columns=cols).to_pandas()
+        print(f"  {p.name}: {len(df):,} rows × {len(cols)} cols")
+        frames.append(df)
+    full = pd.concat(frames, ignore_index=True)
+    print(f"Total: {len(full):,} rows")
+    return full
+
+
+def make_split(df: pd.DataFrame, val_frac: float, test_frac: float,
+               seed: int = 0) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Source-disjoint split on image_basename. Returns boolean masks."""
+    images = pd.Series(df["image_basename"].unique())
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(len(images))
+    n = len(images)
+    n_test = int(round(n * test_frac))
+    n_val = int(round(n * val_frac))
+    test_imgs = set(images.iloc[perm[:n_test]])
+    val_imgs = set(images.iloc[perm[n_test:n_test + n_val]])
+    is_test = df["image_basename"].isin(test_imgs).to_numpy()
+    is_val = df["image_basename"].isin(val_imgs).to_numpy()
+    is_train = ~(is_val | is_test)
+    print(f"Split: train={is_train.sum():,} ({is_train.mean()*100:.1f}%) "
+          f"val={is_val.sum():,} ({is_val.mean()*100:.1f}%) "
+          f"test={is_test.sum():,} ({is_test.mean()*100:.1f}%)")
+    return is_train, is_val, is_test
+
+
+def build_arrays(df: pd.DataFrame, target_col: str
+                  ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    feat_cols = [c for c in df.columns if c.startswith("feat_")
+                 and int(c[5:]) < 228]
+    feat_cols = sorted(feat_cols, key=lambda c: int(c[5:]))
+    n_features = len(feat_cols)
+    print(f"Using {n_features} feature columns: feat_0..feat_{n_features-1}")
+    has_y = df[target_col].notna() & df[target_col].abs().lt(1e6)
+    has_x = df[feat_cols].notna().all(axis=1)
+    keep = has_y & has_x
+    print(f"Dropping {(~keep).sum():,} rows with NaN/inf in target or features")
+    sub = df[keep]
+    X = sub[feat_cols].to_numpy(dtype=np.float32)
+    y = sub[target_col].to_numpy(dtype=np.float32)
+    images = sub["image_basename"].to_numpy()
+    sweep_codec = (sub["sweep_id"] + ":" + sub["codec"]).to_numpy()
+    return X, y, images, sweep_codec
+
+
+class MLP(torch.nn.Module):
+    def __init__(self, n_in: int, hidden: list[int]):
+        super().__init__()
+        layers = []
+        prev = n_in
+        for h in hidden:
+            layers.append(torch.nn.Linear(prev, h))
+            layers.append(torch.nn.LeakyReLU(negative_slope=0.01))
+            prev = h
+        layers.append(torch.nn.Linear(prev, 1))
+        self.net = torch.nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(-1)
+
+
+def ranknet_loss(pred: torch.Tensor, target: torch.Tensor,
+                  groups: torch.Tensor, max_pairs_per_group: int = 64
+                  ) -> torch.Tensor:
+    """Pairwise sigmoid loss within each group (image_basename id)."""
+    device = pred.device
+    losses = []
+    unique_groups, counts = torch.unique(groups, return_counts=True)
+    for g, c in zip(unique_groups.tolist(), counts.tolist()):
+        if c < 2:
+            continue
+        idx = torch.where(groups == g)[0]
+        if c > max_pairs_per_group:
+            sel = idx[torch.randperm(c, device=device)[:max_pairs_per_group]]
+        else:
+            sel = idx
+        p = pred[sel].unsqueeze(1) - pred[sel].unsqueeze(0)
+        t = target[sel].unsqueeze(1) - target[sel].unsqueeze(0)
+        sign = torch.sign(t)
+        mask = (sign != 0)
+        if mask.sum() == 0:
+            continue
+        # Bradley–Terry / RankNet: -log sigmoid(sign * p)
+        l = torch.nn.functional.softplus(-sign[mask] * p[mask])
+        losses.append(l.mean())
+    if not losses:
+        return torch.zeros((), device=device)
+    return torch.stack(losses).mean()
+
+
+def srocc(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size < 2 or b.size < 2:
+        return float("nan")
+    rho, _ = sstats.spearmanr(a, b)
+    return float(rho)
+
+
+def krocc(a: np.ndarray, b: np.ndarray) -> float:
+    if a.size < 2 or b.size < 2:
+        return float("nan")
+    tau, _ = sstats.kendalltau(a, b)
+    return float(tau)
+
+
+@dataclass
+class TrainConfig:
+    target: str
+    loss: str
+    hidden: list[int]
+    epochs: int
+    batch_size: int
+    lr: float
+    weight_decay: float
+    dropout: float
+    rank_weight: float
+    seed: int
+
+
+def train(cfg: TrainConfig, X_train, y_train, g_train,
+          X_val, y_val, g_val, device) -> tuple[MLP, dict]:
+    torch.manual_seed(cfg.seed)
+    n_in = X_train.shape[1]
+    model = MLP(n_in, cfg.hidden).to(device)
+    opt = torch.optim.AdamW(model.parameters(), lr=cfg.lr,
+                            weight_decay=cfg.weight_decay)
+
+    # Pre-bake tensors on GPU
+    Xt = torch.from_numpy(X_train).to(device)
+    yt = torch.from_numpy(y_train).to(device)
+    gt = torch.from_numpy(g_train).to(device)
+    Xv = torch.from_numpy(X_val).to(device)
+    yv = torch.from_numpy(y_val).to(device)
+
+    best = {"epoch": -1, "val_srocc": -1, "val_mse": math.inf,
+            "state": None}
+
+    n = Xt.size(0)
+    bs = min(cfg.batch_size, n)
+    for ep in range(cfg.epochs):
+        model.train()
+        perm = torch.randperm(n, device=device)
+        ep_loss = 0.0
+        n_batches = 0
+        for start in range(0, n, bs):
+            idx = perm[start:start + bs]
+            x = Xt[idx]
+            y = yt[idx]
+            g = gt[idx]
+            pred = model(x)
+            mse = torch.mean((pred - y) ** 2)
+            if cfg.loss == "mse":
+                loss = mse
+            elif cfg.loss == "ranknet":
+                loss = ranknet_loss(pred, y, g)
+            elif cfg.loss == "mse_rank":
+                rk = ranknet_loss(pred, y, g)
+                loss = mse + cfg.rank_weight * rk
+            else:
+                raise ValueError(cfg.loss)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            ep_loss += float(loss.item())
+            n_batches += 1
+
+        model.eval()
+        with torch.no_grad():
+            pv = model(Xv).detach().cpu().numpy()
+        val_mse = float(np.mean((pv - y_val) ** 2))
+        val_sr = srocc(pv, y_val)
+        val_kr = krocc(pv, y_val)
+        if val_sr > best["val_srocc"]:
+            best = {"epoch": ep, "val_srocc": val_sr, "val_mse": val_mse,
+                    "val_krocc": val_kr,
+                    "state": {k: v.detach().clone().cpu()
+                              for k, v in model.state_dict().items()}}
+        print(f"  epoch {ep:3d}  train_loss={ep_loss/max(1,n_batches):.4f}  "
+              f"val_mse={val_mse:.3f}  val_srocc={val_sr:.4f}  "
+              f"val_krocc={val_kr:.4f}", flush=True)
+
+    if best["state"]:
+        model.load_state_dict(best["state"])
+    metrics = {k: v for k, v in best.items() if k != "state"}
+    return model, metrics
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input-dir",
+                    default="/mnt/v/zen/zensim-training/2026-05-07/unified")
+    ap.add_argument("--sweeps", default="v15r,v15rc",
+                    help="Comma-separated sweep ids to train on")
+    ap.add_argument("--target", default="ssim2",
+                    choices=["ssim2", "butteraugli", "butteraugli_p3", "zensim"])
+    ap.add_argument("--loss", default="mse_rank",
+                    choices=["mse", "ranknet", "mse_rank"])
+    ap.add_argument("--hidden", default="64",
+                    help="Comma-separated hidden layer widths")
+    ap.add_argument("--epochs", type=int, default=30)
+    ap.add_argument("--batch-size", type=int, default=8192)
+    ap.add_argument("--lr", type=float, default=1e-3)
+    ap.add_argument("--weight-decay", type=float, default=1e-5)
+    ap.add_argument("--dropout", type=float, default=0.0)
+    ap.add_argument("--rank-weight", type=float, default=0.5)
+    ap.add_argument("--val-frac", type=float, default=0.10)
+    ap.add_argument("--test-frac", type=float, default=0.10)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--max-rows", type=int, default=None,
+                    help="Cap rows for debug runs")
+    ap.add_argument("--out-dir",
+                    default="/mnt/v/zen/zensim-training/2026-05-07/runs")
+    ap.add_argument("--tag", default="v_next")
+    args = ap.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Device: {device}")
+
+    target_col = {
+        "ssim2": "score_ssim2",
+        "butteraugli": "score_butteraugli_max",
+        "butteraugli_p3": "score_butteraugli_pnorm3",
+        "zensim": "score_zensim",
+    }[args.target]
+
+    df = load_parquets(Path(args.input_dir), args.sweeps.split(","))
+    if args.max_rows:
+        df = df.sample(min(args.max_rows, len(df)), random_state=args.seed)\
+               .reset_index(drop=True)
+        print(f"Subsampled to {len(df):,} rows")
+
+    is_tr, is_va, is_te = make_split(df, args.val_frac, args.test_frac, args.seed)
+    X, y, images, sc = build_arrays(df, target_col)
+
+    # Re-mask after dropna so masks align with X/y
+    keep_idx = df.index[df[target_col].notna()
+                        & df[[c for c in df.columns
+                              if c.startswith("feat_") and int(c[5:]) < 228]]
+                        .notna().all(axis=1)]
+    is_tr_x = is_tr[keep_idx]
+    is_va_x = is_va[keep_idx]
+    is_te_x = is_te[keep_idx]
+
+    # Image-id encoding for ranknet groups (only need within-train uniqueness)
+    img_to_id = {n: i for i, n in enumerate(np.unique(images))}
+    g_all = np.array([img_to_id[n] for n in images], dtype=np.int64)
+
+    cfg = TrainConfig(
+        target=args.target, loss=args.loss,
+        hidden=[int(h) for h in args.hidden.split(",")],
+        epochs=args.epochs, batch_size=args.batch_size, lr=args.lr,
+        weight_decay=args.weight_decay, dropout=args.dropout,
+        rank_weight=args.rank_weight, seed=args.seed)
+
+    print(f"Config: {cfg}")
+    print(f"Train rows: {is_tr_x.sum():,}  Val rows: {is_va_x.sum():,}  "
+          f"Test rows: {is_te_x.sum():,}")
+
+    t0 = time.time()
+    model, metrics = train(cfg,
+                            X[is_tr_x], y[is_tr_x], g_all[is_tr_x],
+                            X[is_va_x], y[is_va_x], g_all[is_va_x],
+                            device)
+    train_secs = time.time() - t0
+
+    # Test
+    model.eval()
+    with torch.no_grad():
+        pt = model(torch.from_numpy(X[is_te_x]).to(device)).cpu().numpy()
+    test_mse = float(np.mean((pt - y[is_te_x]) ** 2))
+    test_sr = srocc(pt, y[is_te_x])
+    test_kr = krocc(pt, y[is_te_x])
+    metrics.update({"test_mse": test_mse, "test_srocc": test_sr,
+                    "test_krocc": test_kr,
+                    "train_secs": round(train_secs, 1),
+                    "n_train": int(is_tr_x.sum()),
+                    "n_val": int(is_va_x.sum()),
+                    "n_test": int(is_te_x.sum())})
+    print(f"\nFinal: best_val_srocc={metrics['val_srocc']:.4f} "
+          f"test_srocc={test_sr:.4f} test_krocc={test_kr:.4f} "
+          f"test_mse={test_mse:.3f}  ({train_secs:.0f}s)")
+
+    # Per-codec breakdown on test
+    test_codec = sc[is_te_x]
+    print("\nPer-(sweep:codec) test metrics:")
+    for sc_id in np.unique(test_codec):
+        mask = test_codec == sc_id
+        if mask.sum() < 50:
+            continue
+        a, b = pt[mask], y[is_te_x][mask]
+        print(f"  {sc_id:<24} n={mask.sum():>7,}  "
+              f"srocc={srocc(a,b):+.4f}  krocc={krocc(a,b):+.4f}  "
+              f"mse={float(np.mean((a-b)**2)):.3f}")
+
+    # Save
+    ts = time.strftime("%Y%m%dT%H%M%S")
+    run_dir = Path(args.out_dir) / f"{ts}_{args.tag}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    torch.save(model.state_dict(), run_dir / "model.pt")
+    with open(run_dir / "meta.json", "w") as f:
+        json.dump({"config": asdict(cfg), "metrics": metrics,
+                   "target_col": target_col,
+                   "n_features": int(X.shape[1])}, f, indent=2)
+    # Predictions parquet for downstream analysis
+    val_df = df.iloc[keep_idx][is_va_x].copy().reset_index(drop=True)
+    with torch.no_grad():
+        pv = model(torch.from_numpy(X[is_va_x]).to(device)).cpu().numpy()
+    val_df["pred"] = pv
+    val_df["target_value"] = y[is_va_x]
+    val_df["residual"] = val_df["pred"] - val_df["target_value"]
+    keep_pred_cols = ["sweep_id", "codec", "image_basename", "q",
+                      "knob_tuple_json", "score_zensim", target_col,
+                      "pred", "target_value", "residual"]
+    val_df[[c for c in keep_pred_cols if c in val_df.columns]]\
+        .to_parquet(run_dir / "predictions_val.parquet",
+                    compression="zstd", compression_level=9)
+    print(f"\nWrote {run_dir}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Builds the v_next training infrastructure on top of the v15-series sweep
data that landed last week. Pure tooling + docs — no behavior change
to the shipping zensim API.

- `scripts/v_next/build_unified_parquet.py` — joins `.tsv` + `.features.parquet`
  pairs from each (sweep, codec) into a single zstd-9 parquet at
  `/mnt/v/zen/zensim-training/2026-05-07/unified/`. Coalesces CPU/GPU
  metric column aliases (`score_ssim2{,_gpu}` etc.) and left-joins
  zenanalyze's 33 named features. **Output: 2,374,666 rows × ~350 cols
  across 7 parquets** (v15r 1.79M, v15rc 514k, v13 36k, v14 2.4k, v12
  37k).

- `scripts/v_next/analyze_score_quality.py` — surfaces three failure
  modes from the unified parquet:
  - 71,115 monotonicity violations (zensim score drops as q rises;
    worst -34.3 points)
  - bumpiness (rolling-3-median residual): mean 0.16, p95 0.45 on
    v15r/v15rc; v12/zenavif worst (mean 3.28)
  - **+7..+11 systematic zensim-vs-ssim2 bias on zenjpeg** (p99 +38..+56)
    — calibration drift, not feature-level error

- `scripts/v_next/sync_unified_to_r2.sh` — mirrors local /mnt/v output
  to `s3://zentrain/v_next-training/2026-05-07/unified/` with a
  `_MANIFEST.json` (per-parquet row counts + git commit hash) so future
  vast.ai workers can `aws s3 sync` the snapshot. Already run.

- `scripts/v_next/train_v_next_mlp.py` — PyTorch RankNet/MSE trainer for
  a 228 → H → 1 perceptual MLP. Source-disjoint splitter on
  `image_basename`, `--target {ssim2,butteraugli,butteraugli_p3,zensim}`,
  `--loss {mse,ranknet,mse_rank}`. Local GPU: ~7s/epoch on v15r.

- `docs/PR_24_REVIEW_2026-05-07.md` — categorized review of PR #24.
  Verdict: merge runtime + scaffolding + calibration tooling + KonJND
  anchor; defer in-tree RankNet trainer (885+416 lines, supplant via
  zenanalyze/zentrain); replace V0_4 bake artifact (retrain on the
  unified 2.37M-row parquet).

- `docs/CID22_PAPER_NOTES_2026-05-07.md` — 30-page Sneyers/Ben Baruch/
  Vaxman 2023 contribution to JPEG WG1 AIC-3 (`wg1m99012`). Captures
  the canonical MCOS scale alignment (visually lossless = 90, high =
  65, medium = 50; SSIM2 maps 1:1 to MCOS), per-metric CID22 SROCC
  table, recommended quality ranges, and seven concrete plan
  adjustments derived from the paper (RankNet within-source loss,
  monotonicity penalty, hold out the 49 CID22 references, multi-scale
  6-scale follow-up). Paper PDF mirrored to
  `s3://zentrain/v_next-training/2026-05-07/papers/CID22_wg1m99012.pdf`.

- `.gitignore` — adds `__pycache__/` and `*.pyc`.

## Test plan

- [x] `python3 scripts/v_next/build_unified_parquet.py` runs end-to-end
      across v12/v13/v14/v15r/v15rc — verified via the 2.37M-row output.
- [x] `python3 scripts/v_next/analyze_score_quality.py` runs and emits
      monotonicity_violations.tsv + bumpiness_per_curve.tsv +
      adversarial_pairs_top_disagree.parquet.
- [x] `python3 scripts/v_next/train_v_next_mlp.py --max-rows 50000
      --epochs 5 --tag smoke` smoke-tests against unified_v15r_zenjpeg.parquet
      on local CUDA.
- [x] `bash scripts/v_next/sync_unified_to_r2.sh` mirrors to R2 with
      manifest. R2 prefix verified: `s3://zentrain/v_next-training/2026-05-07/unified/`.

## Followups (NOT in this PR)

- Selectively merge PR #24 runtime + calibration commits onto its own
  branch; drop the in-tree trainer (mlp_train.rs, mlp_importance.rs)
  in a follow-up.
- Refit `score_mapping_a/b` on the unified parquet using PR #24's
  `v04_calibrate_mapping.rs` once that lands.
- Cross-codec sweep (v_next handoff TODO §4.2) on vast.ai.
- Multi-scale invariance probe (TODO §4.3) — paper's 6-scale choice
  argues for adding scales 5+6 to zensim.