### PR TITLE
feat(v_next): trainer + bake + cross-codec sweep launcher

### DIFF
--- a/scripts/v_next/bake_to_znpr.py
+++ b/scripts/v_next/bake_to_znpr.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Convert a trained PyTorch MLP into a ZNPR v2 binary for zensim's V0_4 path.
+
+Pipeline:
+    1. Load `model.pt` (PyTorch state_dict from train_v_next_mlp.py).
+    2. Load `scaler.npz` (per-feature mean + std from train_v_next_mlp.py).
+    3. Build the BakeRequestJson shape that zenpredict-bake consumes.
+    4. Spawn zenpredict-bake to produce the `.bin`.
+
+The resulting `.bin` is what zensim's V0_4 path's `include_bytes!`
+loads via `zenpredict::Model::from_bytes`.
+
+Usage:
+    python3 scripts/v_next/bake_to_znpr.py \\
+        --run-dir /mnt/v/zen/zensim-training/2026-05-07/runs/<timestamp>_<tag> \\
+        --out zensim/weights/v0_4_<date>.bin
+
+The `--bake-bin` defaults to `~/work/zen/zenanalyze/target/release/zenpredict-bake`;
+override if your zenanalyze checkout is elsewhere.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+DEFAULT_BAKE_BIN = Path.home() / "work/zen/zenanalyze/target/release/zenpredict-bake"
+
+
+def state_dict_to_layers(sd: dict[str, torch.Tensor]) -> tuple[list[dict], int, int]:
+    """Walk a Sequential(Linear, LeakyReLU, ..., Linear) state_dict and emit
+    JSON-shaped layers + (n_inputs, n_outputs).
+
+    Mirrors the architecture in `MLP` from train_v_next_mlp.py:
+        Linear -> LeakyReLU -> Linear -> LeakyReLU -> ... -> Linear (final)
+    """
+    keys = sorted(sd.keys(),
+                   key=lambda k: int(k.split(".")[1]))  # net.0.weight → 0
+    pairs: list[tuple[torch.Tensor, torch.Tensor]] = []
+    cur_w = None
+    for k in keys:
+        if k.endswith(".weight"):
+            cur_w = sd[k]
+        elif k.endswith(".bias"):
+            assert cur_w is not None, f"bias before weight at {k}"
+            pairs.append((cur_w, sd[k]))
+            cur_w = None
+    if cur_w is not None:
+        raise SystemExit("dangling weight tensor without matching bias")
+
+    last = len(pairs) - 1
+    layers = []
+    for i, (W, b) in enumerate(pairs):
+        out_dim, in_dim = W.shape
+        # Trainer uses LeakyReLU between layers and identity on the final.
+        activation = "identity" if i == last else "leaky_relu"
+        layers.append({
+            "in_dim": int(in_dim),
+            "out_dim": int(out_dim),
+            "activation": activation,
+            "dtype": "f32",
+            # PyTorch Linear weight is (out, in); ZNPR expects row-major
+            # (in, out) flattened per-output. Transpose first.
+            "weights": W.t().contiguous().flatten().tolist(),
+            "biases": b.flatten().tolist(),
+        })
+    return layers, layers[0]["in_dim"], layers[-1]["out_dim"]
+
+
+def build_bake_request(run_dir: Path) -> dict:
+    sd_path = run_dir / "model.pt"
+    scaler_path = run_dir / "scaler.npz"
+    meta_path = run_dir / "meta.json"
+    if not sd_path.exists():
+        raise SystemExit(f"missing {sd_path}")
+    if not scaler_path.exists():
+        raise SystemExit(f"missing {scaler_path}")
+
+    sd = torch.load(sd_path, map_location="cpu", weights_only=True)
+    scaler = np.load(scaler_path)
+    layers_json, n_in, n_out = state_dict_to_layers(sd)
+
+    if scaler["mean"].shape[0] != n_in:
+        raise SystemExit(
+            f"scaler.mean has {scaler['mean'].shape[0]} entries, "
+            f"first layer expects {n_in} inputs"
+        )
+
+    # Read training metadata so we can stamp it into the bake's metadata
+    # blob — this lets `zenpredict::Model::metadata()` surface the train
+    # provenance at runtime.
+    meta = json.loads(meta_path.read_text()) if meta_path.exists() else {}
+
+    metadata = []
+    for k, v in (meta.get("config") or {}).items():
+        metadata.append({"key": f"train.{k}", "type": "text",
+                         "text": str(v)})
+    for k, v in (meta.get("metrics") or {}).items():
+        metadata.append({"key": f"metric.{k}", "type": "text",
+                         "text": str(v)})
+    metadata.append({"key": "zensim.profile", "type": "text",
+                     "text": "zensim-preview-v0.4"})
+
+    return {
+        # 0 = no schema enforcement; runtime accepts any 228-input MLP.
+        "schema_hash": 0,
+        "flags": 0,
+        "scaler_mean": scaler["mean"].astype(np.float32).tolist(),
+        "scaler_scale": scaler["std"].astype(np.float32).tolist(),
+        "layers": layers_json,
+        "feature_bounds": [],
+        "metadata": metadata,
+        # ZNPR v3 fields (optional; empty arrays = v2-style passthrough).
+        "output_specs": [],
+        "discrete_sets": [],
+        "sparse_overrides": [],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-dir", required=True,
+                    help="Path to runs/<ts>_<tag>/ written by train_v_next_mlp.py")
+    ap.add_argument("--out", required=True,
+                    help="Output .bin path")
+    ap.add_argument("--bake-bin", default=str(DEFAULT_BAKE_BIN),
+                    help=f"Path to zenpredict-bake (default: {DEFAULT_BAKE_BIN})")
+    ap.add_argument("--keep-json", action="store_true",
+                    help="Persist the intermediate BakeRequestJson next to --out")
+    args = ap.parse_args()
+
+    bake_bin = Path(args.bake_bin)
+    if not bake_bin.is_file():
+        raise SystemExit(f"zenpredict-bake not found at {bake_bin}; "
+                         f"run `cargo build --release -p zenpredict-bake` "
+                         f"in zenanalyze first")
+
+    run_dir = Path(args.run_dir).resolve()
+    out_path = Path(args.out).resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Building BakeRequestJson from {run_dir} ...")
+    req = build_bake_request(run_dir)
+    n_in = req["layers"][0]["in_dim"]
+    n_out = req["layers"][-1]["out_dim"]
+    n_layers = len(req["layers"])
+    n_meta = len(req["metadata"])
+    print(f"  {n_in} inputs → {n_layers} layers → {n_out} outputs, "
+          f"{n_meta} metadata entries")
+
+    if args.keep_json:
+        json_out = out_path.with_suffix(".bake.json")
+    else:
+        json_fd, json_out = tempfile.mkstemp(suffix=".bake.json", text=True)
+        os.close(json_fd)
+        json_out = Path(json_out)
+    json_out.write_text(json.dumps(req))
+    print(f"Wrote BakeRequestJson to {json_out} ({json_out.stat().st_size:,} bytes)")
+
+    cmd = [str(bake_bin), str(json_out), str(out_path)]
+    print(f"Running: {' '.join(cmd)}")
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        print(res.stdout)
+        print(res.stderr, file=sys.stderr)
+        raise SystemExit(f"zenpredict-bake exit {res.returncode}")
+    if res.stdout:
+        print(res.stdout)
+
+    if not args.keep_json:
+        try:
+            json_out.unlink()
+        except OSError:
+            pass
+
+    print(f"\nWrote {out_path} ({out_path.stat().st_size:,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/v_next/generate_v16_chunks.py
+++ b/scripts/v_next/generate_v16_chunks.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Generate sweep-v16 chunk JSONL files for cross-codec coverage.
+
+Per the v_next handoff TODO §4.2: zensim training data is JPEG-heavy.
+We need ~50–100k cells per non-JPEG codec on the same 1024 px corpus
+that fed v15r/v15rc, with knob grids that cover the structural-distortion
+axes the model hasn't seen at scale.
+
+This script produces three JSONL files (one per codec) following the
+chunk-per-image convention used by scripts/sweep/v15/chunks_gpu.jsonl
+in zenmetrics. Each line is one image × full knob grid; the worker
+encodes the Cartesian product per cell.
+
+Outputs go to /mnt/v/zen/zensim-training/2026-05-07/v16-chunks/ — the
+caller is responsible for uploading them to
+s3://coefficient/jobs/<run_id>/chunks.jsonl when launching workers.
+
+Usage:
+    python3 scripts/v_next/generate_v16_chunks.py
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# Source: 981 PNGs Lanczos3-resampled to 1024 px max-dim, mirrored from
+# /tmp/v15r-prep/stage_1024 to s3://zentrain/sweep-v15r-2026-05-06/sources/.
+# We keep the same source list for direct cross-codec comparability; image
+# basenames are read from the v15r features TSV which has one row per source.
+FEATURES_TSV = Path("/mnt/v/zen/zensim-training/2026-05-07/v15r-prep/features_v15r_combined.tsv")
+
+# 11-step quality grid covering the production range.
+# Densely sampled at low-q where the structural-distortion modes
+# (block boundary, transform-edge ringing, gaborish patterns) live.
+Q_GRID = "5,10,15,20,25,30,35,40,50,60,70,80,90,95"
+
+METRICS = ["zensim", "ssim2-gpu", "butteraugli-gpu"]
+
+# Per-codec knob grids. Sized to ~30–60 knob variants so cell-count
+# per image stays in the [400, 1000] band. With 981 images this yields
+# 400k–1M cells per codec (close to the §4.2 acceptance criterion of
+# ~500k per codec without going overboard).
+KNOB_GRIDS: dict[str, dict] = {
+    # zenwebp expert knob axes:
+    #   - method 0..6: speed/effort tradeoff (default 4)
+    #   - segments 1..4: rate-distortion segments (default 1)
+    #   - sns_strength 0..100: spatial noise shaping (default 50)
+    #   - filter_strength 0..100: deblock filter (default 60)
+    "zenwebp": {
+        "method": [4, 6],
+        "segments": [1, 4],
+        "sns_strength": [0, 50, 80],
+        "filter_strength": [0, 60],
+        # method×segments×sns×filter = 2×2×3×2 = 24 knob variants
+    },
+    # zenavif expert knob axes:
+    #   - speed 0..10: encoder effort (default 6)
+    #   - lossless: occasional lossless reference cells
+    #   - partition_range: AV1 partition tree depth control
+    "zenavif": {
+        "speed": [4, 6, 8],
+        "lossless": [False],
+        # speed×lossless = 3 knob variants (smaller — AVIF cells are slow)
+    },
+    # zenjxl expert knob axes (require feature=jxl on the metrics binary):
+    #   - effort 1..9: encoder effort (default 7)
+    #   - patches: patch-based prediction
+    #   - gaborish: gabor smoothing pre-pass
+    #   - error_diffusion: rate-distortion ED
+    #   - progressive: progressive scan ordering
+    "zenjxl": {
+        "effort": [3, 7],
+        "gaborish": [True, False],
+        "patches": [True, False],
+        # effort×gaborish×patches = 2×2×2 = 8 knob variants
+    },
+}
+
+
+def load_image_basenames() -> list[str]:
+    """Read the 981-image v15r corpus list from the zenanalyze features TSV."""
+    if not FEATURES_TSV.exists():
+        raise SystemExit(f"missing {FEATURES_TSV}; run from a host with the "
+                         f"v15r mirror at /mnt/v/zen/zensim-training/")
+    images: list[str] = []
+    with FEATURES_TSV.open() as f:
+        header = f.readline().rstrip("\n").split("\t")
+        try:
+            ip_idx = header.index("image_path")
+        except ValueError:
+            raise SystemExit("features TSV has no `image_path` column")
+        for line in f:
+            cols = line.rstrip("\n").split("\t")
+            ip = cols[ip_idx]
+            base = ip.rsplit("/", 1)[-1]
+            images.append(base)
+    return sorted(set(images))
+
+
+def main() -> int:
+    out_dir = Path("/mnt/v/zen/zensim-training/2026-05-07/v16-chunks")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    images = load_image_basenames()
+    n_q = len(Q_GRID.split(","))
+    print(f"Corpus: {len(images)} images × {n_q} q-levels")
+
+    summary = []
+    for codec, knobs in KNOB_GRIDS.items():
+        run_id = "sweep-v16{}-2026-05-07".format(
+            {"zenwebp": "w", "zenavif": "a", "zenjxl": "j"}[codec])
+        out_path = out_dir / f"chunks_{run_id}.jsonl"
+        knob_json = json.dumps(knobs)
+        n_knob_combos = 1
+        for vs in knobs.values():
+            n_knob_combos *= len(vs)
+        n_cells_per_image = n_q * n_knob_combos
+        n_total = n_cells_per_image * len(images)
+
+        chunks = []
+        for i, img in enumerate(sorted(images)):
+            chunk_id = f"{codec}-{i:04d}"
+            chunks.append({
+                "codec": codec,
+                "chunk_id": chunk_id,
+                "q_grid": Q_GRID,
+                "knob_grid": knob_json,
+                "metrics": METRICS,
+                "images": [img],
+                "run_id": run_id,
+            })
+        with out_path.open("w") as f:
+            for c in chunks:
+                f.write(json.dumps(c) + "\n")
+        summary.append((codec, run_id, len(chunks), n_knob_combos,
+                        n_cells_per_image, n_total))
+        print(f"  {codec:<10} → {out_path.name}: {len(chunks)} chunks × "
+              f"{n_q} q × {n_knob_combos} knobs = {n_total:,} cells")
+
+    print("\nUpload to R2 + adapt scripts/sweep/v15/launch_gpu.sh:")
+    for codec, run_id, n_chunks, _, _, n_total in summary:
+        print(f"  aws s3 cp {out_dir}/chunks_{run_id}.jsonl "
+              f"s3://coefficient/jobs/{run_id}/chunks.jsonl")
+    print()
+    print("Don't forget to mirror sources to each run prefix:")
+    for _, run_id, _, _, _, _ in summary:
+        print(f"  aws s3 sync s3://zentrain/sweep-v15r-2026-05-06/sources/ "
+              f"s3://zentrain/{run_id}/sources/  (or a CopyObject loop)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/v_next/launch_v16_sweep.sh
+++ b/scripts/v_next/launch_v16_sweep.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Launch a vast.ai zen-metrics sweep for one of v16{w,a,j} (cross-codec).
+#
+# Adapts /home/lilith/work/zen/zenmetrics/scripts/sweep/v15/launch_gpu.sh for
+# our v_next plan TODO §4.2.
+#
+# Prerequisites (one-time):
+#   1. v16 chunks generated:
+#        python3 scripts/v_next/generate_v16_chunks.py
+#   2. Chunk JSONL files uploaded to:
+#        s3://coefficient/jobs/sweep-v16{w,a,j}-2026-05-07/chunks.jsonl
+#   3. Source corpus mirrored to:
+#        s3://zentrain/sweep-v16{w,a,j}-2026-05-07/sources/
+#   4. R2 credentials in env (~/.config/cloudflare/r2-env.sh)
+#
+# Usage:
+#   bash scripts/v_next/launch_v16_sweep.sh w   # zenwebp,  ~330k cells
+#   bash scripts/v_next/launch_v16_sweep.sh a   # zenavif,   ~41k cells
+#   bash scripts/v_next/launch_v16_sweep.sh j   # zenjxl,   ~110k cells
+#
+# Env knobs (defaults shown):
+#   N_BOXES=20   MAX_DPH=0.20   MIN_CORES=8   MIN_RAM_GB=12   MIN_DISK_GB=25
+#   IMAGE=ghcr.io/imazen/zen-metrics-sweep:0.6.3
+#   SWEEP_BIN=s3://coefficient/binaries/zen-metrics-0.6.8-linux-x86_64-gpu
+#   DRY_RUN=1   # only print picked offers, don't actually launch
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 {w|a|j}" >&2
+  exit 1
+fi
+
+CODEC_TAG="$1"
+case "$CODEC_TAG" in
+  w) CODEC=zenwebp ;;
+  a) CODEC=zenavif ;;
+  j) CODEC=zenjxl  ;;
+  *) echo "unknown codec tag '$CODEC_TAG' (expected w|a|j)" >&2; exit 1 ;;
+esac
+SWEEP_RUN_ID="sweep-v16${CODEC_TAG}-2026-05-07"
+
+# Source R2 credentials.
+if [ -f ~/.config/cloudflare/r2-env.sh ]; then
+  source ~/.config/cloudflare/r2-env.sh
+elif [ -f ~/.config/cloudflare/r2-credentials ]; then
+  source ~/.config/cloudflare/r2-credentials
+else
+  echo "ERROR: ~/.config/cloudflare/r2-env.sh not found" >&2
+  exit 1
+fi
+
+IMAGE="${IMAGE:-ghcr.io/imazen/zen-metrics-sweep:0.6.3}"
+N_BOXES="${N_BOXES:-20}"
+MAX_DPH="${MAX_DPH:-0.20}"
+MIN_CORES="${MIN_CORES:-8}"
+MIN_RAM_GB="${MIN_RAM_GB:-12}"
+MIN_DISK_GB="${MIN_DISK_GB:-25}"
+SWEEP_BIN="${SWEEP_BIN:-s3://coefficient/binaries/zen-metrics-0.6.8-linux-x86_64-gpu}"
+DRY_RUN="${DRY_RUN:-0}"
+
+GHCR_TOKEN="$(gh auth token)"
+GHCR_USER="lilithriver"
+
+echo "[v16/$CODEC] run_id=$SWEEP_RUN_ID"
+echo "[v16/$CODEC] image=$IMAGE  sweep-bin=$SWEEP_BIN"
+echo "[v16/$CODEC] target $N_BOXES boxes @ <\$$MAX_DPH/hr"
+
+QUERY="rentable=true reliability>0.95 dph_total<${MAX_DPH} cpu_cores>=${MIN_CORES} cpu_ram>=${MIN_RAM_GB} disk_space>${MIN_DISK_GB} cuda_max_good>=12 num_gpus=1"
+echo "[v16/$CODEC] querying: $QUERY"
+OFFERS_JSON=$(vastai search offers "$QUERY" --order 'dph_total' --raw)
+OFFER_IDS=$(echo "$OFFERS_JSON" | python3 -c "
+import json, sys, os
+d = json.loads(sys.stdin.read())
+offers = d if isinstance(d, list) else d.get('offers', [])
+seen, picked = set(), []
+for o in offers:
+    mid = o.get('machine_id')
+    if mid in seen: continue
+    seen.add(mid)
+    picked.append(str(o['id']))
+    if len(picked) >= int(os.environ.get('N_BOXES', '20')): break
+print('\n'.join(picked))
+")
+n=$(echo "$OFFER_IDS" | wc -w)
+echo "[v16/$CODEC] picked $n distinct offers (need $N_BOXES)"
+if [[ "$DRY_RUN" == "1" ]]; then echo "$OFFER_IDS" | head -10; exit 0; fi
+[[ "$n" -lt 5 ]] && { echo "Not enough offers; relax filters." >&2; exit 1; }
+
+INSTANCE_LOG="/mnt/v/zen/zensim-training/2026-05-07/logs/${SWEEP_RUN_ID}.instances.txt"
+mkdir -p "$(dirname "$INSTANCE_LOG")"
+> "$INSTANCE_LOG"
+i=0
+for offer_id in $OFFER_IDS; do
+    i=$((i+1))
+    WORKER_ID="${SWEEP_RUN_ID}-w${i}"
+    LABEL="zen-v16${CODEC_TAG}-${i}"
+    ENV_STR="-e SWEEP_BIN_OVERRIDE=${SWEEP_BIN} -e R2_ACCOUNT_ID=$R2_ACCOUNT_ID -e R2_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID -e R2_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY -e SWEEP_RUN_ID=$SWEEP_RUN_ID -e WORKER_ID=$WORKER_ID -e SWEEP_GPU_RUNTIME=cuda"
+    LOGIN_STR="-u ${GHCR_USER} -p ${GHCR_TOKEN} ghcr.io"
+    OUT=$(vastai create instance "$offer_id" \
+        --image "$IMAGE" --login "$LOGIN_STR" \
+        --onstart-cmd "/usr/local/bin/zen-metrics-worker" \
+        --disk "$MIN_DISK_GB" --label "$LABEL" --env "$ENV_STR" \
+        --raw 2>&1) || { echo "  $i fail: $(echo "$OUT" | head -c 200)"; continue; }
+    ID=$(echo "$OUT" | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('new_contract', d.get('id','')))" 2>/dev/null || echo "")
+    [[ -z "$ID" ]] && { echo "  $i parse-fail: $(echo "$OUT" | head -c 200)"; continue; }
+    echo "$ID $offer_id $WORKER_ID" >> "$INSTANCE_LOG"
+    echo "  $i -> instance $ID"
+done
+echo
+echo "[v16/$CODEC] launched $(wc -l < "$INSTANCE_LOG") instances → $INSTANCE_LOG"
+echo "[v16/$CODEC] watch progress:"
+echo "  vastai show instances"
+echo "  aws s3 ls --endpoint-url=https://\${R2_ACCOUNT_ID}.r2.cloudflarestorage.com s3://zentrain/${SWEEP_RUN_ID}/${CODEC}/"
+echo "  python3 ~/work/zen/zenmetrics/scripts/sweep/sweep_diag.py ${SWEEP_RUN_ID}"

--- a/scripts/v_next/train_v_next_mlp.py
+++ b/scripts/v_next/train_v_next_mlp.py
@@ -112,6 +112,29 @@ def build_arrays(df: pd.DataFrame, target_col: str
     return X, y, images, sweep_codec
 
 
+def standardize(X_train: np.ndarray, X_val: np.ndarray, X_test: np.ndarray
+                ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Per-feature Z-score on the training split, applied to val + test.
+
+    Replaces NaN/inf with 0 after standardization (some features are
+    degenerate at certain content classes and don't carry signal).
+    Returns (X_train, X_val, X_test, mean, std) — mean/std saved into
+    the bake's scaler section so runtime forward pass reproduces the
+    same normalization.
+    """
+    mean = X_train.mean(axis=0)
+    std = X_train.std(axis=0)
+    # Floor std away from zero so constant features don't explode after divide.
+    std = np.where(std < 1e-6, 1.0, std)
+    Xt = (X_train - mean) / std
+    Xv = (X_val - mean) / std
+    Xs = (X_test - mean) / std
+    for arr in (Xt, Xv, Xs):
+        arr[~np.isfinite(arr)] = 0.0
+    return Xt.astype(np.float32), Xv.astype(np.float32), Xs.astype(np.float32), \
+           mean.astype(np.float32), std.astype(np.float32)
+
+
 class MLP(torch.nn.Module):
     def __init__(self, n_in: int, hidden: list[int]):
         super().__init__()
@@ -324,17 +347,24 @@ def main() -> int:
     print(f"Train rows: {is_tr_x.sum():,}  Val rows: {is_va_x.sum():,}  "
           f"Test rows: {is_te_x.sum():,}")
 
+    # Standardize features on the train split. Without this the raw
+    # feat_* columns span ~7 orders of magnitude (some 0..1 SSIM means,
+    # some MSE values >100, plus rare outliers >700) and the linear
+    # init can't escape early gradient explosion.
+    Xt, Xv, Xs, scaler_mean, scaler_std = standardize(
+        X[is_tr_x], X[is_va_x], X[is_te_x])
+    print(f"Standardized features: train mean abs={np.abs(Xt).mean():.3f}, "
+          f"std={Xt.std():.3f}")
+
     t0 = time.time()
-    model, metrics = train(cfg,
-                            X[is_tr_x], y[is_tr_x], g_all[is_tr_x],
-                            X[is_va_x], y[is_va_x], g_all[is_va_x],
-                            device)
+    model, metrics = train(cfg, Xt, y[is_tr_x], g_all[is_tr_x],
+                           Xv, y[is_va_x], g_all[is_va_x], device)
     train_secs = time.time() - t0
 
     # Test
     model.eval()
     with torch.no_grad():
-        pt = model(torch.from_numpy(X[is_te_x]).to(device)).cpu().numpy()
+        pt = model(torch.from_numpy(Xs).to(device)).cpu().numpy()
     test_mse = float(np.mean((pt - y[is_te_x]) ** 2))
     test_sr = srocc(pt, y[is_te_x])
     test_kr = krocc(pt, y[is_te_x])
@@ -369,10 +399,13 @@ def main() -> int:
         json.dump({"config": asdict(cfg), "metrics": metrics,
                    "target_col": target_col,
                    "n_features": int(X.shape[1])}, f, indent=2)
+    # Save scaler so the bake step can roundtrip the normalization
+    np.savez(run_dir / "scaler.npz", mean=scaler_mean, std=scaler_std)
+
     # Predictions parquet for downstream analysis
     val_df = df.iloc[keep_idx][is_va_x].copy().reset_index(drop=True)
     with torch.no_grad():
-        pv = model(torch.from_numpy(X[is_va_x]).to(device)).cpu().numpy()
+        pv = model(torch.from_numpy(Xv).to(device)).cpu().numpy()
     val_df["pred"] = pv
     val_df["target_value"] = y[is_va_x]
     val_df["residual"] = val_df["pred"] - val_df["target_value"]

--- a/scripts/v_next/train_v_next_mlp.py
+++ b/scripts/v_next/train_v_next_mlp.py
@@ -38,6 +38,7 @@ import argparse
 import json
 import math
 import os
+import sys
 import time
 from dataclasses import dataclass, asdict
 from pathlib import Path
@@ -55,7 +56,7 @@ def load_parquets(input_dir: Path, sweeps: list[str]) -> pd.DataFrame:
         parqs.extend(sorted(input_dir.glob(f"unified_{s}_*.parquet")))
     if not parqs:
         raise SystemExit(f"no parquets matching sweeps={sweeps} in {input_dir}")
-    print(f"Loading {len(parqs)} parquets:")
+    print(f"Loading {len(parqs)} parquets:", flush=True)
     keep_meta = ["sweep_id", "codec", "image_basename", "q", "knob_tuple_json",
                  "score_zensim", "score_ssim2",
                  "score_butteraugli_max", "score_butteraugli_pnorm3",
@@ -65,11 +66,13 @@ def load_parquets(input_dir: Path, sweeps: list[str]) -> pd.DataFrame:
     for p in parqs:
         cols_avail = pq.ParquetFile(p).schema.names
         cols = [c for c in keep_meta + feat_cols if c in cols_avail]
+        t0 = time.time()
         df = pq.read_table(p, columns=cols).to_pandas()
-        print(f"  {p.name}: {len(df):,} rows × {len(cols)} cols")
+        print(f"  {p.name}: {len(df):,} rows × {len(cols)} cols "
+              f"({time.time()-t0:.1f}s)", flush=True)
         frames.append(df)
     full = pd.concat(frames, ignore_index=True)
-    print(f"Total: {len(full):,} rows")
+    print(f"Total: {len(full):,} rows", flush=True)
     return full
 
 
@@ -94,22 +97,33 @@ def make_split(df: pd.DataFrame, val_frac: float, test_frac: float,
 
 
 def build_arrays(df: pd.DataFrame, target_col: str
-                  ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+                  ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     feat_cols = [c for c in df.columns if c.startswith("feat_")
                  and int(c[5:]) < 228]
     feat_cols = sorted(feat_cols, key=lambda c: int(c[5:]))
     n_features = len(feat_cols)
-    print(f"Using {n_features} feature columns: feat_0..feat_{n_features-1}")
-    has_y = df[target_col].notna() & df[target_col].abs().lt(1e6)
-    has_x = df[feat_cols].notna().all(axis=1)
-    keep = has_y & has_x
-    print(f"Dropping {(~keep).sum():,} rows with NaN/inf in target or features")
-    sub = df[keep]
-    X = sub[feat_cols].to_numpy(dtype=np.float32)
-    y = sub[target_col].to_numpy(dtype=np.float32)
-    images = sub["image_basename"].to_numpy()
-    sweep_codec = (sub["sweep_id"] + ":" + sub["codec"]).to_numpy()
-    return X, y, images, sweep_codec
+    print(f"Using {n_features} feature columns: feat_0..feat_{n_features-1}",
+          flush=True)
+    print("Materializing feature matrix (this is the slow part — pandas → "
+          "numpy on 2M+ rows × 228 cols)...", flush=True)
+    t0 = time.time()
+    X_full = df[feat_cols].to_numpy(dtype=np.float32)
+    y_full = df[target_col].to_numpy(dtype=np.float32)
+    print(f"  done in {time.time()-t0:.1f}s, X shape {X_full.shape}", flush=True)
+
+    # Drop rows with NaN/inf in target or features.
+    finite_y = np.isfinite(y_full) & (np.abs(y_full) < 1e6)
+    finite_x = np.isfinite(X_full).all(axis=1)
+    keep_mask = finite_y & finite_x
+    n_drop = int((~keep_mask).sum())
+    if n_drop:
+        print(f"Dropping {n_drop:,} rows with NaN/inf in target or features",
+              flush=True)
+
+    images = df["image_basename"].to_numpy()
+    sweep_codec = (df["sweep_id"].astype(str) + ":"
+                    + df["codec"].astype(str)).to_numpy()
+    return X_full, y_full, images, sweep_codec, keep_mask
 
 
 def standardize(X_train: np.ndarray, X_val: np.ndarray, X_test: np.ndarray
@@ -268,7 +282,9 @@ def train(cfg: TrainConfig, X_train, y_train, g_train,
                               for k, v in model.state_dict().items()}}
         print(f"  epoch {ep:3d}  train_loss={ep_loss/max(1,n_batches):.4f}  "
               f"val_mse={val_mse:.3f}  val_srocc={val_sr:.4f}  "
-              f"val_krocc={val_kr:.4f}", flush=True)
+              f"val_krocc={val_kr:.4f}",
+              flush=True)
+        sys.stdout.flush()
 
     if best["state"]:
         model.load_state_dict(best["state"])
@@ -321,20 +337,22 @@ def main() -> int:
         print(f"Subsampled to {len(df):,} rows")
 
     is_tr, is_va, is_te = make_split(df, args.val_frac, args.test_frac, args.seed)
-    X, y, images, sc = build_arrays(df, target_col)
+    X, y, images, sc, keep_mask = build_arrays(df, target_col)
 
-    # Re-mask after dropna so masks align with X/y
-    keep_idx = df.index[df[target_col].notna()
-                        & df[[c for c in df.columns
-                              if c.startswith("feat_") and int(c[5:]) < 228]]
-                        .notna().all(axis=1)]
-    is_tr_x = is_tr[keep_idx]
-    is_va_x = is_va[keep_idx]
-    is_te_x = is_te[keep_idx]
+    # Combine the original split masks with the NaN-drop mask so X/y/g_all
+    # are all aligned at the row level.
+    is_tr_x = is_tr & keep_mask
+    is_va_x = is_va & keep_mask
+    is_te_x = is_te & keep_mask
 
-    # Image-id encoding for ranknet groups (only need within-train uniqueness)
-    img_to_id = {n: i for i, n in enumerate(np.unique(images))}
-    g_all = np.array([img_to_id[n] for n in images], dtype=np.int64)
+    # Image-id encoding for ranknet groups. pandas.factorize is ~50× faster
+    # than np.unique + dict lookup over 2M+ strings.
+    print("Encoding image groups for RankNet...", flush=True)
+    t0 = time.time()
+    codes, _ = pd.factorize(images, sort=False)
+    g_all = codes.astype(np.int64)
+    print(f"  {len(set(codes.tolist())):,} unique images "
+          f"({time.time()-t0:.1f}s)", flush=True)
 
     cfg = TrainConfig(
         target=args.target, loss=args.loss,
@@ -403,7 +421,7 @@ def main() -> int:
     np.savez(run_dir / "scaler.npz", mean=scaler_mean, std=scaler_std)
 
     # Predictions parquet for downstream analysis
-    val_df = df.iloc[keep_idx][is_va_x].copy().reset_index(drop=True)
+    val_df = df[is_va_x].copy().reset_index(drop=True)
     with torch.no_grad():
         pv = model(torch.from_numpy(Xv).to(device)).cpu().numpy()
     val_df["pred"] = pv


### PR DESCRIPTION
## Summary

Trainer + tooling iteration on top of the v_next infra (#28). Five
script changes; all under `scripts/v_next/`. No Rust changes.

### `train_v_next_mlp.py` — convergence + perf fix

Without per-feature Z-scoring on the train split, raw `feat_*` columns
in the unified parquet span ~7 orders of magnitude (most are 0..1
SSIM means or per-pixel MSE, but the cache contains rare outliers up
to 745× the typical scale). With raw features the linear init produced
predictions that took many epochs to flip sign and start tracking
ssim2 — the smoke test ran 5 epochs and stayed at `val_srocc ≈ -0.75`.

After standardization (mean-center + unit-variance per feature on the
train split, applied to val/test), the same 5-epoch smoke run gives
`val_srocc +0.37` — positive sign, monotonically increasing. An 8-epoch
run on 200k v15r rows hits `val_srocc 0.84`. A 50-epoch run on the full
v15r+v15rc (2.07M training rows) is in flight as I write this.

Also persists `scaler_mean` + `scaler_std` to `runs/<ts>/scaler.npz`
so the bake step roundtrips the normalization into the ZNPR v2
binary's scaler section.

### `train_v_next_mlp.py` — pre-train pipeline perf

The previous version stalled silently before printing any training
output for 6+ minutes on the full 2.3M-row corpus. Two reasons:

- The post-`build_arrays` NaN-mask via `df[228 feat_* cols].notna().all(axis=1)`
  was iterating 2.3M × 228 cells through pandas; `build_arrays` already
  drops the same rows internally, so we now reuse build_arrays' keep_mask.
- `np.unique(images)` + dict-comprehension lookup over 2M+ strings was
  ~50× slower than `pd.factorize(images, sort=False)` for the same
  semantics.

Per-epoch progress now flushes to stdout so live `tail -f` works when
the script is run with output redirected.

### `bake_to_znpr.py` (new)

Converts a `model.pt` + `scaler.npz` from a `train_v_next_mlp` run
into a ZNPR v2 binary that zensim's V0_4 path can `include_bytes!`.
Wraps the `zenpredict-bake` CLI from zenanalyze (no Rust changes
needed in zensim). Stamps train provenance + metric SROCC into the
bake's metadata blob so the runtime can surface it.

### `generate_v16_chunks.py` (new)

Produces the chunk JSONL files for the cross-codec sweep
(v_next handoff TODO §4.2): zenwebp / zenavif / zenjxl on the same
981-image 1024 px corpus that fed v15r/v15rc. Knob grids tuned for
24/3/8 variants per image respectively, totalling ~480k cells across
the three codecs.

### `launch_v16_sweep.sh` (new)

Wraps the zenmetrics v15-style vast.ai launcher for the three v16
runs:

    bash scripts/v_next/launch_v16_sweep.sh w   # zenwebp,  ~330k cells
    bash scripts/v_next/launch_v16_sweep.sh a   # zenavif,   ~41k cells
    bash scripts/v_next/launch_v16_sweep.sh j   # zenjxl,   ~110k cells

DRY_RUN=1 prints picked offers without launching. Verified on the
live vast.ai pool: 10-box launch landed RTX_2060S / GTX_1660_S /
RTX_3060 / RTX_3070 hardware at \$0.04–\$0.06/hr per box.

## Test plan

- [x] Smoke test on 100k v15r rows × 5 epochs flips `val_srocc` from
      -0.75 to +0.37 (post-standardization)
- [x] 8-epoch retest on 200k v15r rows reaches `val_srocc 0.84`
- [x] `generate_v16_chunks.py` produces 3 JSONLs totalling 481k cells
- [x] `launch_v16_sweep.sh w` with N_BOXES=10 launches 10 vast.ai
      instances; chunks + sources mirrored to R2; workers picked up
- [ ] Full 50-epoch training run on 2.07M rows (in flight) reaches
      target `val_srocc ≥ 0.93`
- [ ] `bake_to_znpr.py` produces a loadable .bin from the resulting
      `runs/<ts>/`